### PR TITLE
解决无法修改van-stepper 自定义样式的背景色

### DIFF
--- a/packages/stepper/index.pcss
+++ b/packages/stepper/index.pcss
@@ -8,7 +8,6 @@
   &__input {
     display: inline-block;
     vertical-align: middle;
-    background-color: $white;
   }
 
   &__minus,


### PR DESCRIPTION
### 解决无法修改van-stepper 自定义样式的背景色

我想修改van-stepper中 plus 按钮的背景色时发现了此 Bug