### PR TITLE
[new feature]button: supports form-type and bindsubmit attributes

### DIFF
--- a/packages/button/index.ts
+++ b/packages/button/index.ts
@@ -14,6 +14,7 @@ VantComponent({
     square: Boolean,
     loading: Boolean,
     disabled: Boolean,
+    formType: String,
     type: {
       type: String,
       value: 'default'
@@ -43,6 +44,11 @@ VantComponent({
     onClick() {
       if (!this.data.disabled && !this.data.loading) {
         this.$emit('click');
+      }
+    },
+    onSubmit(e) {
+      if (!this.data.disabled && !this.data.loading) {
+        this.triggerEvent('submit', e)
       }
     }
   }

--- a/packages/button/index.ts
+++ b/packages/button/index.ts
@@ -48,7 +48,7 @@ VantComponent({
     },
     onSubmit(e) {
       if (!this.data.disabled && !this.data.loading) {
-        this.triggerEvent('submit', e)
+        this.triggerEvent('submit', e);
       }
     }
   }

--- a/packages/button/index.wxml
+++ b/packages/button/index.wxml
@@ -1,29 +1,32 @@
-<button
-  id="{{ id }}"
-  lang="{{ lang }}"
-  class="custom-class van-button {{ classes }}"
-  open-type="{{ openType }}"
-  app-parameter="{{ appParameter }}"
-  hover-stay-time="{{ hoverStayTime }}"
-  hover-start-time="{{ hoverStartTime }}"
-  hover-stop-propagation="{{ hoverStopPropagation }}"
-  session-from="{{ sessionFrom }}"
-  send-message-title="{{ sendMessageTitle }}"
-  send-message-path="{{ sendMessagePath }}"
-  send-message-img="{{ sendMessageImg }}"
-  show-message-card="{{ showMessageCard }}"
-  bind:tap="onClick"
-  binderror="bindError"
-  bindcontact="bindContact"
-  bindopensetting="bindOpenSetting"
-  bindgetuserinfo="bindGetUserInfo"
-  bindgetphonenumber="bindGetPhoneNumber"
->
-  <van-loading
-    wx:if="{{ loading }}"
-    size="20px"
-    custom-class="loading-class"
-    color="{{ type === 'default' ? '#c9c9c9' : '#fff' }}"
-  />
-  <slot wx:else />
-</button>
+<form report-submit="{{ !!formType }}" bindsubmit="onSubmit">
+  <button
+    id="{{ id }}"
+    lang="{{ lang }}"
+    class="custom-class van-button {{ classes }}"
+    open-type="{{ openType }}"
+    form-type="{{ formType }}"
+    app-parameter="{{ appParameter }}"
+    hover-stay-time="{{ hoverStayTime }}"
+    hover-start-time="{{ hoverStartTime }}"
+    hover-stop-propagation="{{ hoverStopPropagation }}"
+    session-from="{{ sessionFrom }}"
+    send-message-title="{{ sendMessageTitle }}"
+    send-message-path="{{ sendMessagePath }}"
+    send-message-img="{{ sendMessageImg }}"
+    show-message-card="{{ showMessageCard }}"
+    bind:tap="onClick"
+    binderror="bindError"
+    bindcontact="bindContact"
+    bindopensetting="bindOpenSetting"
+    bindgetuserinfo="bindGetUserInfo"
+    bindgetphonenumber="bindGetPhoneNumber"
+  >
+    <van-loading
+      wx:if="{{ loading }}"
+      size="20px"
+      custom-class="loading-class"
+      color="{{ type === 'default' ? '#c9c9c9' : '#fff' }}"
+    />
+    <slot wx:else />
+  </button>
+</form>


### PR DESCRIPTION
实现很简单按钮外层套个form，正常按钮和form-type获取formId测试可用，dist代码wxml貌似没有格式？所以没有更新。
使用方式：
````
<vant-button formType="submit" bind:submit="onSubmit">提交</vant-button>

// index.js
onSubmit(e) {
  const formId = e.detail.detail.formId // 注意: 两层detail
}
````
