### PR TITLE
修复steps样式组件

### DIFF
--- a/packages/steps/index.less
+++ b/packages/steps/index.less
@@ -113,8 +113,12 @@
     line-height: 18px;
     padding: 10px 10px 10px 0;
 
-    &:not(:last-child)::after {
+    &::after {
       border-bottom-width: 1px;
+    }
+
+    &:last-child::after {
+      border-bottom-width: none;
     }
 
     &:first-child {


### PR DESCRIPTION

#### 标题规则
[bugfix] steps：修复index.less中底部边框选择器在微信开发者工具中运行“自动运行体验评分”css选择器报错


修复 #1013 

pull request 改动点:

- 改动一更改&--vertical选择器
