### PR TITLE
[improvement] dialog表单组件：可以使用传递出的dialog实例的stopLoading()手动关闭按钮的loading状态

### DIFF
--- a/packages/dialog/index.ts
+++ b/packages/dialog/index.ts
@@ -91,7 +91,9 @@ VantComponent({
         this.close();
       }
       this.$emit('close', action);
-      this.$emit(action);
+      
+      //把dialog实例传递出去，可以通过stopLoading()在外部关闭按钮的loading
+      this.$emit(action, {dialog: this});
 
       const callback = this.data[action === 'confirm' ? 'onConfirm' : 'onCancel'];
       if (callback) {

--- a/packages/dialog/index.ts
+++ b/packages/dialog/index.ts
@@ -92,8 +92,8 @@ VantComponent({
       }
       this.$emit('close', action);
       
-      //把dialog实例传递出去，可以通过stopLoading()在外部关闭按钮的loading
-      this.$emit(action, {dialog: this});
+      //把 dialog 实例传递出去，可以通过 stopLoading() 在外部关闭按钮的 loading
+      this.$emit(action, { dialog: this });
 
       const callback = this.data[action === 'confirm' ? 'onConfirm' : 'onCancel'];
       if (callback) {


### PR DESCRIPTION
pull request 改动点:

- [packages/dialog/index.ts]第94行
   this.$emit(action); 改成：
   //把dialog实例传递出去，可以通过stopLoading()在外部关闭按钮的loading
   this.$emit(action, {dialog: this});
