### PR TITLE
[Bugfix] Stepper: allow delete input to empty (solution 1)

### DIFF
--- a/packages/stepper/index.ts
+++ b/packages/stepper/index.ts
@@ -14,7 +14,7 @@ VantComponent({
   ],
 
   props: {
-    value: Number,
+    value: [Number, String],
     integer: Boolean,
     disabled: Boolean,
     asyncChange: Boolean,
@@ -45,6 +45,7 @@ VantComponent({
 
   watch: {
     value(value) {
+      if (value === '') return;
       this.set({
         value: this.range(value)
       });

--- a/packages/stepper/index.ts
+++ b/packages/stepper/index.ts
@@ -14,7 +14,7 @@ VantComponent({
   ],
 
   props: {
-    value: [Number, String],
+    value: null,
     integer: Boolean,
     disabled: Boolean,
     asyncChange: Boolean,
@@ -45,10 +45,11 @@ VantComponent({
 
   watch: {
     value(value) {
-      if (value === '') return;
-      this.set({
-        value: this.range(value)
-      });
+      if (value !== '') {
+        this.set({
+          value: this.range(value)
+        });
+      }
     }
   },
 


### PR DESCRIPTION
我尝试了两种修复方式，不确定哪一种会更符合 vant 的设计，所以希望提交两个 PR，请你们帮忙选择。

When the stepper has value '1' and the user tries to edit the value
directly to '50', the input field stop user from delete '1' to ''.

The reason for the bug is `props: { value: Number }` trying to
convert empty string to 0, then `watch: { value() {} }` will set 0
to 1 automatically.

This fix tries to:

* allow type String for `value` to support empty string ''
* stop convert '' to 0 from the watcher

The bug was introduced from 696ae3c.

Resolves: #1151
