### PR TITLE
[Bugfix] Stepper: allow delete input to empty (solution 2)

### DIFF
--- a/packages/stepper/index.ts
+++ b/packages/stepper/index.ts
@@ -14,7 +14,10 @@ VantComponent({
   ],
 
   props: {
-    value: Number,
+    // HACK: do not enable type checks for `value`
+    // It stops the user to delete the input to empty string,
+    // which is very common when you trying to modify '1' to '50'
+    // value: Number,
     integer: Boolean,
     disabled: Boolean,
     asyncChange: Boolean,


### PR DESCRIPTION
我尝试了两种修复方式，不确定哪一种会更符合 vant 的设计，所以希望提交两个 PR，请你们帮忙选择。

When the stepper has value '1' and the user tries to edit the value
directly to '50', the input field stop user from delete '1' to ''.

The reason for the bug is `props: { value: Number }` trying to
convert empty string to 0, then `watch: { value() {} }` will set 0
to 1 automatically.

This fix tries to:

* disable type check for `value` prop

The bug was introduced from 696ae3c.

Resolves: #1151
