### PR TITLE
Popup 添加 `transitionEnd` 事件

### DIFF
--- a/example/pages/popup/index.js
+++ b/example/pages/popup/index.js
@@ -11,6 +11,9 @@ Page({
     }
   },
 
+  onTransitionEnd() {
+    console.log(`You can't see me 🌚`);
+  },
   toggle(type) {
     this.setData({
       [`show.${type}`]: !this.data.show[type]

--- a/example/pages/popup/index.wxml
+++ b/example/pages/popup/index.wxml
@@ -4,6 +4,7 @@
     show="{{ show.middle }}"
     custom-class="center"
     bind:close="togglePopup"
+    bind:transitionEnd="onTransitionEnd"
   >
     内容
   </van-popup>
@@ -17,6 +18,7 @@
     position="bottom"
     custom-class="bottom"
     bind:close="toggleBottomPopup"
+    bind:transitionEnd="onTransitionEnd"
   >
     内容
   </van-popup>
@@ -28,6 +30,7 @@
     overlay="{{ false }}"
     custom-class="top"
     bind:close="toggleTopPopup"
+    bind:transitionEnd="onTransitionEnd"
   >
     内容
   </van-popup>
@@ -38,6 +41,7 @@
     position="right"
     custom-class="right"
     bind:close="toggleRightPopup"
+    bind:transitionEnd="onTransitionEnd"
   >
     <van-button bind:click="toggleRightPopup" class="demo-margin-right">关闭弹层</van-button>
 
@@ -47,6 +51,7 @@
       position="right"
       custom-class="right"
       bind:close="toggleRightPopup2"
+      bind:transitionEnd="onTransitionEnd"
     >
       <van-button bind:click="toggleRightPopup2">关闭弹层</van-button>
     </van-popup>

--- a/packages/popup/README.md
+++ b/packages/popup/README.md
@@ -62,6 +62,7 @@ Page({
 |-----------|-----------|-----------|
 | bind:close | 蒙层关闭时触发 | - |
 | bind:click-overlay | 点击蒙层时触发 | - |
+| bind:transitionEnd | 蒙层关闭后触发 | - |
 
 ### 外部样式类
 

--- a/packages/popup/index.ts
+++ b/packages/popup/index.ts
@@ -53,6 +53,10 @@ VantComponent({
       }
     },
 
+    onTransitionEnd() {
+      !this.data.show && this.$emit('transitionEnd');
+    },
+
     observeClass() {
       const { transition, position } = this.data;
       this.updateClasses(transition || position);


### PR DESCRIPTION
## 动机
假设现在有一个需求，我们的 `ListItem` 具有触发 PopUp 的能力。有两种方式可以做到：
1. 在 `ListItem` 中声明 `Popup`，通过 `wx:if` 来做到性能优化。
2. 在 `ListItem` 的父组件，比如 `List` 中声明，通过在 `ListItem`  中 `triggerEvent` 来发生 `PopUp` 所需要的数据。

第二种方式目前常用的方式，因为如果直接用 `wx:if` 判断的话，关闭 `Popup` 时没有动画，导致整个过程很生硬。而现有的生命周期又不满足需求，所以通过在 `transtion` 后，将 `wx:if` 改为 false 就能拿到效果。

虽然我们可以继续使用第二种方式，但是它很容易让 `List` 变成一个非常庞大的组件。这里有一个 `Popup`，那里又有一个 `Popup`，不知不觉就变成了 `PopUp` 中转站。所以，通过添加这个事件，可以在一定程序上减少对 `List` 的依赖。更关注 `ListItem` 本身。
