### PR TITLE
解决openType传不到button组件的问题

### DIFF
--- a/packages/button/index.ts
+++ b/packages/button/index.ts
@@ -8,6 +8,7 @@ VantComponent({
   classes: ['hover-class', 'loading-class'],
 
   props: {
+    openType: String,
     plain: Boolean,
     block: Boolean,
     round: Boolean,

--- a/packages/mixins/open-type.ts
+++ b/packages/mixins/open-type.ts
@@ -1,6 +1,5 @@
 export const openType = Behavior({
-  properties: {
-    openType: String
+  properties: { 
   },
 
   methods: {


### PR DESCRIPTION
使用环境：我在使用vant-weapp时，直接把 dist 目录放在小程序根目录。
发现问题：然后在index 页面引用 button组件，发现openType 传不到button中，
简单解决：一番查找之后把mixins/open-type.js 中的 openType 属性 拿到 button/index.js中 props 里 发现可以用了。
