### PR TITLE
[bugfix] Collapse: 默认展开情况下动态增加内容高度自适应

### DIFF
--- a/packages/collapse-item/index.ts
+++ b/packages/collapse-item/index.ts
@@ -42,6 +42,9 @@ VantComponent({
       .then(nextTick)
       .then(() => {
         this.set({ transition: true });
+      })
+      .then(() => {
+        this.onTransitionEnd();
       });
   },
 


### PR DESCRIPTION
修复 #1817 。

pull request 改动点:

- collapse-item组件初次挂载完成，如果默认为展开则高度改为auto（手动执行一下onTransitionEnd方法）
