### PR TITLE
[bug fix] Area: 修复area组件，当columns-num等于2时，设置value，第一项省级永远显示北京市

### DIFF
--- a/dist/area/index.js
+++ b/dist/area/index.js
@@ -26,7 +26,9 @@ VantComponent({
         }
     },
     mounted() {
-        this.setValues();
+        setTimeout(() => {
+            this.setValues()
+        }, 0)
     },
     methods: {
         getPicker() {

--- a/packages/area/index.ts
+++ b/packages/area/index.ts
@@ -44,7 +44,9 @@ VantComponent({
   },
 
   mounted() {
-    this.setValues();
+    setTimeout(()=>{
+      this.setValues()
+    }, 0)
   },
 
   methods: {


### PR DESCRIPTION
修复 #1318 