### PR TITLE
[fix] Icon: should not render info when value is empty string

### DIFF
--- a/packages/info/index.wxml
+++ b/packages/info/index.wxml
@@ -1,5 +1,5 @@
 <view
-  wx:if="{{ info !== null }}"
+  wx:if="{{ info !== null && info !== '' }}"
   class="custom-class van-info"
   style="{{ customStyle }}"
 >{{ info }}</view>


### PR DESCRIPTION
https://github.com/youzan/vant-weapp/issues/1882