### PR TITLE
fix(checkbox): set a 12px icon size style bug

### DIFF
--- a/packages/checkbox/index.less
+++ b/packages/checkbox/index.less
@@ -16,7 +16,9 @@
   }
 
   &__icon {
-    display: block;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     box-sizing: border-box;
     width: 1em;
     height: 1em;

--- a/packages/goods-action-button/index.ts
+++ b/packages/goods-action-button/index.ts
@@ -24,7 +24,7 @@ VantComponent({
     }
   },
 
-  mounted: function() {
+  mounted() {
     this.updateStyle();
   },
 
@@ -34,12 +34,13 @@ VantComponent({
       this.jumpLink();
     },
     updateStyle() {
-      const parent = this.parent;
+      const { parent } = this;
       const { children = [] } = parent;
       const index = children.indexOf(this);
-      const length = children.length;
-      let isFirst = false, isLast = false;
-      if ( index === 0 ) {
+      const { length } = children;
+      let isFirst = false; let
+        isLast = false;
+      if (index === 0) {
         isFirst = true;
       }
       if (index === length - 1) {

--- a/packages/goods-action-button/index.ts
+++ b/packages/goods-action-button/index.ts
@@ -38,8 +38,8 @@ VantComponent({
       const { children = [] } = parent;
       const index = children.indexOf(this);
       const { length } = children;
-      let isFirst = false; let
-        isLast = false;
+      let isFirst = false;
+      let isLast = false;
       if (index === 0) {
         isFirst = true;
       }


### PR DESCRIPTION
设置 `icon-size` 为小像素时，由于子元素 `inline-block` 导致的样式bug

![image](https://user-images.githubusercontent.com/16181940/65747542-4c875f80-e134-11e9-81bb-c26c0e3a5728.png)
