### PR TITLE
feat(van-progress): Add customizable progress track color

### DIFF
--- a/dist/progress/index.js
+++ b/dist/progress/index.js
@@ -15,6 +15,10 @@ VantComponent({
             type: String,
             value: BLUE
         },
+        trackColor: {
+            type: String,
+            value: "#e5e5e5",
+        },
         textColor: {
             type: String,
             value: '#fff'

--- a/dist/progress/index.wxml
+++ b/dist/progress/index.wxml
@@ -1,6 +1,6 @@
 <wxs src="./index.wxs" module="getters" />
 
-<view class="van-progress custom-class" style="height: {{ strokeWidthUnit }};">
+<view class="van-progress custom-class" style="height: {{ strokeWidthUnit }}; background: {{trackColor}};">
   <view
     class="van-progress__portion"
     style="width: {{ percentage }}%; background: {{ inactive ? '#cacaca' : color }}"


### PR DESCRIPTION
### Pull Request 标题规则

- feat(van-progress)：Add the customizable track color of van-progress, users now can set param 'trackColor' to designated color to change the track color.

示例：

- docs: fix typo in quickstart
- build: optimize build speed
- fix(Button): incorrect style
- feat(Button): add color prop

可选择的类型:

- fix
- feat
- docs
- perf
- test
- types
- build
- chore
- refactor
- breaking change
