### PR TITLE
breaking change(tabbar): remove tag selector

### DIFF
--- a/packages/tabbar-item/index.less
+++ b/packages/tabbar-item/index.less
@@ -32,12 +32,6 @@
         .theme(background-color, '@red');
       }
     }
-
-    image {
-      display: block;
-      width: 30px;
-      height: 18px;
-    }
   }
 
   &--active {


### PR DESCRIPTION
由于微信小程序禁止使用标签选择器，因此移除了 Tabbar 内部的标签选择器样式，由用户自行控制