### PR TITLE
fix(NoticeBar): catch tap event of close icon @rex-zsd

### DIFF
--- a/packages/notice-bar/index.wxml
+++ b/packages/notice-bar/index.wxml
@@ -24,7 +24,7 @@
     wx:if="{{ mode === 'closeable' }}"
     class="van-notice-bar__right-icon"
     name="cross"
-    bind:tap="onClickIcon"
+    catch:tap="onClickIcon"
   />
   <navigator
     wx:elif="{{ mode === 'link' }}"


### PR DESCRIPTION
fix #2246 