### PR TITLE
fix(Tabs): 修复选项卡竖向滚动时触发scroll事件

### DIFF
--- a/packages/tabs/index.ts
+++ b/packages/tabs/index.ts
@@ -327,7 +327,7 @@ VantComponent({
           const child = this.children[currentIndex - 1];
           this.setActive(child.getComputedName());
         } else if (deltaX < 0 && currentIndex !== tabs.length - 1) {
-          const child = this.children[currentIndex - 1];
+          const child = this.children[currentIndex + 1];
           this.setActive(child.getComputedName());
         }
       }

--- a/packages/tabs/index.ts
+++ b/packages/tabs/index.ts
@@ -304,7 +304,7 @@ VantComponent({
     onTouchScroll(event: Weapp.TouchEvent) {
       this.$emit('scroll', event.detail);
     },
-    
+
     onTouchStart(event: Weapp.TouchEvent) {
       if (!this.data.swipeable) return;
 

--- a/packages/tabs/index.ts
+++ b/packages/tabs/index.ts
@@ -301,6 +301,11 @@ VantComponent({
       );
     },
 
+    onTouchScroll(event) {
+      const { detail } = event;
+      this.$emit('scroll', detail);
+    },
+    
     onTouchStart(event: Weapp.TouchEvent) {
       if (!this.data.swipeable) return;
 

--- a/packages/tabs/index.ts
+++ b/packages/tabs/index.ts
@@ -301,9 +301,8 @@ VantComponent({
       );
     },
 
-    onTouchScroll(event) {
-      const { detail } = event;
-      this.$emit('scroll', detail);
+    onTouchScroll(event: Weapp.TouchEvent) {
+      this.$emit('scroll', event.detail);
     },
     
     onTouchStart(event: Weapp.TouchEvent) {

--- a/packages/tabs/index.wxml
+++ b/packages/tabs/index.wxml
@@ -1,7 +1,7 @@
 <wxs src="../wxs/utils.wxs" module="utils" />
 
 <view class="custom-class {{ utils.bem('tabs', [type]) }}">
-  <van-sticky disabled="{{ !sticky }}" z-index="{{ zIndex }}" offset-top="{{ offsetTop }}">
+  <van-sticky disabled="{{ !sticky }}" z-index="{{ zIndex }}" offset-top="{{ offsetTop }}" bind:scroll="onTouchScroll">
     <view class="{{ utils.bem('tabs__wrap', { scrollable }) }} {{ type === 'line' && border ? 'van-hairline--top-bottom' : '' }}">
       <slot name="nav-left" />
 


### PR DESCRIPTION

tabs选项卡当使用吸顶sticky功能时，没有scroll事件。