### PR TITLE
fix: use lib as miniprogram

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.2",
   "author": "youzan",
   "license": "MIT",
-  "miniprogram": "dist",
+  "miniprogram": "lib",
   "description": "轻量、可靠的小程序 UI 组件库",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
在使用过程中,如果不使用开发工具的es5转es6功能,语法报错.
不使用开发工具的原因是开发工具在转的时候用的babel的方式,会在某些情况下会出错(我使用的情况比较复杂一些,对于出错的情况不太好解释,总之这个功能鸡肋得很).所以我不能在项目中开启es6到es5的转化.
我搞不懂的是有赞的这个包为什么这么设计,既然用ts开发的代码,直接target设成es5编译不就什么事都没有了,为什么还要在lib目录之外,编译一个es6的版本出来,并且还让微信小程序的开发工具在构建的时候使用es6的版本.我看了源码并且考虑过,实在是没能够想明白.