### PR TITLE
fix(Sticky): 调整Sticky是否fixed的判断，当top===offsetTop时也应该判断为fixed

### DIFF
--- a/packages/sticky/index.ts
+++ b/packages/sticky/index.ts
@@ -130,8 +130,8 @@ VantComponent({
 
       const fixed =
         containerHeight && height
-          ? top >= height - containerHeight && top < offsetTop
-          : top < offsetTop;
+          ? top >= height - containerHeight && top <= offsetTop
+          : top <= offsetTop;
 
       this.$emit('scroll', {
         scrollTop: top,


### PR DESCRIPTION
当前判断是top < offsetTop ，item必须滚动出屏幕（1px这样）然后才会设置为fixed会造成item闪动