### PR TITLE
fix(datetime-picker，dropdown-menu,dropdown-item) 时间组件data-time 默认值为string报错  dropdown-menu,dropdown-item 穿透及关闭事件触发问题

### DIFF
--- a/packages/datetime-picker/index.ts
+++ b/packages/datetime-picker/index.ts
@@ -234,8 +234,8 @@ VantComponent({
       }
 
       // date type
-      value = Math.max(value, data.minDate);
-      value = Math.min(value, data.maxDate);
+      value = Math.max(new Date(value).getTime(), data.minDate);
+      value = Math.min(new Date(value).getTime(), data.maxDate);
 
       return value;
     },

--- a/packages/dropdown-item/index.ts
+++ b/packages/dropdown-item/index.ts
@@ -126,5 +126,8 @@ VantComponent({
         this.rerender();
       }
     },
+    catchTouchmove:function(e) {
+      return;
+    },
   },
 });

--- a/packages/dropdown-item/index.ts
+++ b/packages/dropdown-item/index.ts
@@ -122,6 +122,7 @@ VantComponent({
           this.rerender();
         });
       } else {
+        this.onClosed();
         this.rerender();
       }
     },

--- a/packages/dropdown-item/index.wxml
+++ b/packages/dropdown-item/index.wxml
@@ -7,7 +7,7 @@
 >
   <van-popup
     show="{{ showPopup }}"
-    custom-style="position: absolute;{{ popupStyle }}"
+    custom-style="position: absolute;height:{{options.length>5?'51%':'auto'}};{{popupStyle }}"
     overlay-style="position: absolute;"
     overlay="{{ overlay }}"
     position="{{ direction === 'down' ? 'top' : 'bottom' }}"
@@ -27,6 +27,7 @@
       clickable
       icon="{{ item.icon }}"
       bind:tap="onOptionTap"
+      atchtouchmove="{{options.length>5?'':'catchTouchmove'}}"
     >
       <view
         slot="title"

--- a/packages/dropdown-menu/index.ts
+++ b/packages/dropdown-menu/index.ts
@@ -139,5 +139,8 @@ VantComponent({
         this.toggleItem(index);
       }
     },
+    catchTouchmove:function(e) {
+      return;
+    },
   },
 });

--- a/packages/dropdown-menu/index.wxml
+++ b/packages/dropdown-menu/index.wxml
@@ -8,6 +8,7 @@
     data-index="{{ index }}"
     class="{{ utils.bem('dropdown-menu__item', { disabled: item.disabled }) }}"
     bind:tap="onTitleTap"
+    catchtouchmove="catchTouchmove"
   >
     <view
       class="{{ item.titleClass }} {{ utils.bem('dropdown-menu__title', { active: item.showPopup, down: item.showPopup === (direction === 'down') }) }}"


### PR DESCRIPTION
修复 两处问题
1、时间组件文档上写有默认值为number or string，在传入string 时 correctValue为date校验时 string 和 number对比会返回NAN，增加统一处理转换格式为number进行对比。
报错截图:

![image](https://user-images.githubusercontent.com/14096175/83726441-1a8cac80-a676-11ea-905b-ac4a6a124c36.png)

2、在特殊情况下调用toggle方法后,再次打开下拉菜单点击效果无效
验证方式 在打开弹窗,立即调用toggle()方法后，再次打开下拉菜单，点击事件无法触发。



