### PR TITLE
fix:uploader组件增加单张只读属性

### DIFF
--- a/packages/uploader/README.md
+++ b/packages/uploader/README.md
@@ -65,6 +65,32 @@ Page({
         url: 'http://iph.href.lu/60x60?text=default',
         name: '图片2',
         isImage: true,
+        deletable: true,
+      },
+    ],
+  },
+});
+```
+
+### 图片编辑状态
+
+通过`deletable `可以标识所有图片或者单张图片是否可删除。如果`Props `的全局`deletable `为`false`，则所有图片都不展示删除按钮；如果`Props `的全局`deletable `为`true`，则可通过设置每一个图片对象里的`deletable `来控制每一张图片是否显示删除按钮，如果图片对象里不设置则默认为`true`。
+
+```html
+<van-uploader file-list="{{ fileList }}" deletable="{{ true }}" />
+```
+
+```js
+Page({
+  data: {
+    fileList: [
+      {
+        url: 'https://img.yzcdn.cn/vant/leaf.jpg',
+        deletable: true,
+      },
+      {
+        url: 'https://img.yzcdn.cn/vant/tree.jpg',
+        deletable: false,
       },
     ],
   },

--- a/packages/uploader/index.ts
+++ b/packages/uploader/index.ts
@@ -77,6 +77,10 @@ VantComponent({
           typeof item.isImage === 'undefined'
             ? isImageFile(item)
             : item.isImage,
+        deletable:
+          typeof item.deletable === 'undefined'
+            ? true
+            : item.deletable,
       }));
       this.setData({ lists, isInCount: lists.length < maxCount });
     },

--- a/packages/uploader/index.wxml
+++ b/packages/uploader/index.wxml
@@ -38,7 +38,7 @@
        <text wx:if="{{ item.message }}" class="van-uploader__upload-text">{{ item.message }}</text>
       </view>
       <view
-        wx:if="{{ deletable }}"
+        wx:if="{{ deletable && !item.onlyRead }}"
         data-index="{{ index }}"
         class="van-uploader__preview-delete"
         catch:tap="deleteItem"

--- a/packages/uploader/index.wxml
+++ b/packages/uploader/index.wxml
@@ -38,7 +38,7 @@
        <text wx:if="{{ item.message }}" class="van-uploader__upload-text">{{ item.message }}</text>
       </view>
       <view
-        wx:if="{{ deletable && !item.onlyRead }}"
+        wx:if="{{ deletable && item.deletable }}"
         data-index="{{ index }}"
         class="van-uploader__preview-delete"
         catch:tap="deleteItem"


### PR DESCRIPTION
uploader组件，deletable属性只能控制全局是否可以删除，不能控制单张图片是否可删除；因此当fileList内为对象时，增加onlyRead标识，当onlyRead为true时，单张不显示删除icon。