### PR TITLE
Update index.ts

### DIFF
--- a/packages/index-bar/index.ts
+++ b/packages/index-bar/index.ts
@@ -95,16 +95,21 @@ VantComponent({
     setAnchorsRect() {
       return Promise.all(
         this.children.map((anchor) =>
-          anchor
-            .getRect('.van-index-anchor-wrapper')
-            .then(
-              (rect: WechatMiniprogram.BoundingClientRectCallbackResult) => {
-                Object.assign(anchor, {
-                  height: rect.height,
-                  top: rect.top + this.scrollTop,
-                });
-              }
-            )
+          let scrollTop = 0;
+
+          return anchor
+            .createSelectorQuery()
+            .selectViewport()
+            .scrollOffset((res) => {
+              scrollTop = res.scrollTop;
+            })
+            .select('.van-index-anchor-wrapper')
+            .boundingClientRect((rect: WechatMiniprogram.BoundingClientRectCallbackResult) => {
+              Object.assign(anchor, {
+                height: rect.height,
+                top: rect.top + scrollTop,
+              });
+            }).exec();
         )
       );
     },


### PR DESCRIPTION
- fix(index-bar?)：解决index-anchor.top值错误问题，在boundingClientRect计算过程中同时触发onPageScroll回调导致。