### PR TITLE
fix(calendar): confirmDisabledText增加默认值和文档同步

### DIFF
--- a/dist/calendar/index.js
+++ b/dist/calendar/index.js
@@ -41,7 +41,10 @@ VantComponent({
       },
     },
     allowSameDay: Boolean,
-    confirmDisabledText: String,
+    confirmDisabledText: {
+      type: String,
+      value: '确定',
+    },
     type: {
       type: String,
       value: 'single',

--- a/dist/datetime-picker/index.js
+++ b/dist/datetime-picker/index.js
@@ -203,8 +203,8 @@ VantComponent({
         return `${hour}:${minute}`;
       }
       // date type
-      value = Math.max(value, data.minDate);
-      value = Math.min(value, data.maxDate);
+      value = Math.max(new Date(value).getTime(), data.minDate);
+      value = Math.min(new Date(value).getTime(), data.maxDate);
       return value;
     },
     getBoundary(type, innerValue) {


### PR DESCRIPTION
fix(datetime-picker): 默认值为string 解析时间错误
fix(calendar): confirmDisabledText增加默认值和文档同步

datetime-picker 文档描述
![image](https://user-images.githubusercontent.com/14096175/87640902-f7c3dc80-c779-11ea-8c63-7ca6d7b0b407.png)

实例传入String值报错截图
![image](https://user-images.githubusercontent.com/14096175/83726441-1a8cac80-a676-11ea-905b-ac4a6a124c36.png)

calendar 示例默认值
![image](https://user-images.githubusercontent.com/14096175/87639699-38baf180-c778-11ea-81ab-278ad70aeceb.png)



