### PR TITLE
feat(tree-select): add active-text prop

### DIFF
--- a/example/pages/tree-select/index.js
+++ b/example/pages/tree-select/index.js
@@ -17,8 +17,34 @@ const items = [
   },
 ];
 
+const customTextItems = [
+  {
+    name: config.pro1Name,
+    children: config.pro1.map((item) => {
+      item.name = item.text;
+      return item;
+    }),
+  },
+  {
+    name: config.pro2Name,
+    children: config.pro2.map((item) => {
+      item.name = item.text;
+      return item;
+    }),
+  },
+  {
+    name: config.pro3Name,
+    disabled: true,
+    children: config.pro3.map((item) => {
+      item.name = item.text;
+      return item;
+    }),
+  },
+];
+
 Page({
   data: {
+    customTextItems,
     items,
     badgeItems: items.slice(0, 2).map((item, index) => {
       if (index === 0) {

--- a/example/pages/tree-select/index.wxml
+++ b/example/pages/tree-select/index.wxml
@@ -19,6 +19,17 @@
   ></van-tree-select>
 </demo-block>
 
+<demo-block title="自定义展示名称">
+  <van-tree-select
+    items="{{ customTextItems}}"
+    main-active-index="{{ mainActiveIndex }}"
+    active-id="{{ activeId }}"
+    active-text="name"
+    bind:click-item="onClickItem"
+    bind:click-nav="onClickNav"
+  ></van-tree-select>
+</demo-block>
+
 <demo-block title="自定义内容">
   <van-tree-select
     items="{{ [{ text: '分组 1' }, { text: '分组 2' }] }}"

--- a/packages/tree-select/README.md
+++ b/packages/tree-select/README.md
@@ -114,6 +114,7 @@ Page({
 | height | 高度，默认单位为`px` | _number \| string_ | `300` |
 | main-active-index | 左侧选中项的索引 | _number_ | `0` | - |
 | active-id | 右侧选中项的 id，支持传入数组 | _string \| number \| Array_ | `0` | - |
+| active-text | 左侧和右侧选项中展示的key | _string_ | `text` |
 | max | 右侧项最大选中个数 | _number_ | _Infinity_ | - |
 | selected-icon `v1.5.0` | 自定义右侧栏选中状态的图标 | _string_ | `success` |
 

--- a/packages/tree-select/index.ts
+++ b/packages/tree-select/index.ts
@@ -17,6 +17,10 @@ VantComponent({
       observer: 'updateSubItems',
     },
     activeId: null,
+    activeText: {
+      type: String,
+      value: 'text',
+    },
     mainActiveIndex: {
       type: Number,
       value: 0,

--- a/packages/tree-select/index.wxml
+++ b/packages/tree-select/index.wxml
@@ -15,7 +15,7 @@
         disabled-class="main-disabled-class"
         badge="{{ item.badge }}"
         dot="{{ item.dot }}"
-        title="{{ item.text }}"
+        title="{{ item[activeText] }}"
         disabled="{{ item.disabled }}"
       />
     </van-sidebar>
@@ -29,7 +29,7 @@
       data-item="{{ item }}"
       bind:tap="onSelectItem"
     >
-      {{ item.text }}
+      {{ item[activeText] }}
       <van-icon
         wx:if="{{ wxs.isActive(activeId, item.id) }}"
         name="{{ selectedIcon }}"


### PR DESCRIPTION
### feat(tree-select): add active-text prop   
       
左侧和右侧选项中展示的key，之前默认是`text`，不够灵活，现在添加一个<code>active-text</code>用来自定义