### PR TITLE
fix(Field): showWordLimit value.length > maxlength

### DIFF
--- a/packages/field/index.wxml
+++ b/packages/field/index.wxml
@@ -99,7 +99,7 @@
     </view>
   </view>
   <view wx:if="{{ showWordLimit && maxlength }}" class="van-field__word-limit">
-    <view class="{{ utils.bem('field__word-num', { full: value.length >= maxlength }) }}">{{ value.length }}</view>/{{ maxlength }}
+    <view class="{{ utils.bem('field__word-num', { full: value.length >= maxlength }) }}">{{ value.length >= maxlength ? maxlength : value.length }}</view>/{{ maxlength }}
   </view>
   <view wx:if="{{ errorMessage }}" class="{{ utils.bem('field__error-message', [errorMessageAlign, { disabled, error }]) }}">
     {{ errorMessage }}


### PR DESCRIPTION
### value.length > maxlength

fix(Field): Clicking on the keyboard to associate words causes the current number of words to exceed the limit, but the actual number does not exceed
Disconnect the real machine for debugging

