### PR TITLE
Update link.ts

### DIFF
--- a/packages/mixins/link.ts
+++ b/packages/mixins/link.ts
@@ -10,8 +10,12 @@ export const link = Behavior({
   methods: {
     jumpLink(urlKey = 'url') {
       const url = this.data[urlKey];
-      if (url) {
-        wx[this.data.linkType]({ url });
+      if (url) {        
+        if (this.data.linkType === 'navigateTo' && getCurrentPages().length > 9) {
+          wx.redirectTo({ url });
+        } else {
+          wx[this.data.linkType]({ url });
+        }
       }
     },
   },


### PR DESCRIPTION
fix(mixins): 页面栈上限后导致的跳转失败