### PR TITLE
fix(Calendar): display 'NaN/NaN/NaN' in phone device after select date

### DIFF
--- a/example/pages/calendar/index.js
+++ b/example/pages/calendar/index.js
@@ -40,7 +40,7 @@ Page({
     this.setData({ showCalendar: false });
 
     this.setData({
-      [`date.${this.data.id}`]: event.detail
+      [`date.${this.data.id}`]: event.detail.valueOf()
     });
   },
 


### PR DESCRIPTION
In wxs file, `getDate(datestring)` return an error 'Invalid Date' in phone device, using `getDate(milliseconds)` replace it