### PR TITLE
docs(quickstart):修复文档快速开始适配新版小程序开发者工具

### DIFF
--- a/docs/markdown/quickstart.md
+++ b/docs/markdown/quickstart.md
@@ -46,6 +46,7 @@ npm i vant-weapp -S --production
   }
 }
 ```
+注意： 由于目前新版开发者工具创建的小程序目录文件结构问题，npm构建的文件目录为miniprogram_npm，并且开发工具会默认在当前目录下创建miniprogram_npm的文件名，所以新版本的miniprogramNpmDistDir配置为'./'即可
 
 ### 步骤四 构建 npm 包
 


### PR DESCRIPTION
目前新版开发者工具创建的小程序目录文件结构问题，npm构建的文件目录为miniprogram_npm，并且开发工具会默认在当前目录下创建miniprogram_npm的文件名，所以新版本的miniprogramNpmDistDir配置为'./'即可

### Pull Request 标题规则

type(ComponentName?)：commit message

示例：

- docs: fix typo in quickstart
- build: optimize build speed
- fix(Button): incorrect style
- feat(Button): add color prop

可选择的类型:

- fix
- feat
- docs
- perf
- test
- types
- build
- chore
- refactor
- breaking change
