### PR TITLE
[fix]:修复tabs在初始化的时候active的值被tabs的默认值给覆盖掉的问题

### DIFF
--- a/packages/tabs/index.ts
+++ b/packages/tabs/index.ts
@@ -131,7 +131,7 @@ VantComponent({
           this.children.length > data.swipeThreshold || !data.ellipsis,
       });
 
-      this.setCurrentIndexByName(this.getCurrentName() || data.active);
+      this.setCurrentIndexByName(data.active || this.getCurrentName());
     },
 
     trigger(eventName: string, child?: TrivialInstance) {


### PR DESCRIPTION
fix(tabs)：修复tabs在初始化的时候active的值被tabs的默认值给覆盖掉的问题