### PR TITLE
feat(Icon): using local icon by default

### DIFF
--- a/packages/icon/index.less
+++ b/packages/icon/index.less
@@ -1,5 +1,5 @@
 @import '../common/style/var.less';
-@import '@vant/icons/src/index.less';
+@import '@vant/icons/src/encode-woff2.less';
 
 :host {
   display: inline-flex;


### PR DESCRIPTION
默认使用 base64 格式的图标，而不是有赞 CDN 上的图标。

优点：

- 不再依赖有赞 CDN
- 开发者工具不再会出现 `Failed to load font` 的错误

缺点：

- 小程序包体积变大