### PR TITLE
fix(Cell): 调整设置is-link的表现

### DIFF
--- a/example/pages/cell/index.wxml
+++ b/example/pages/cell/index.wxml
@@ -29,6 +29,13 @@
   </van-cell-group>
 </demo-block>
 
+<demo-block title="有点击反馈">
+  <van-cell-group>
+    <van-cell title="单元格" clickable />
+    <van-cell title="单元格" is-link clickable />
+  </van-cell-group>
+</demo-block>
+
 <demo-block title="展示图标">
   <van-cell
     title="单元格"

--- a/packages/cell/index.wxml
+++ b/packages/cell/index.wxml
@@ -2,7 +2,7 @@
 <wxs src="./index.wxs" module="computed" />
 
 <view
-  class="custom-class {{ utils.bem('cell', [size, { center, required, borderless: !border, clickable: isLink || clickable }]) }}"
+  class="custom-class {{ utils.bem('cell', [size, { center, required, borderless: !border, clickable }]) }}"
   hover-class="van-cell--hover hover-class"
   hover-stay-time="70"
   style="{{ customStyle }}"


### PR DESCRIPTION
fix(Cell): 调整设置is-link的表现
原来是设置is-link之后就一定有点击反馈，但是在使用中想要is-link的右侧箭头并且不想看到点击反馈就没有办法做到，当然设置右侧icon也是可以的，但是链接点击一定有反馈这个规则其实有待思考，建议考虑