### PR TITLE
fix(van-datetime-picker): incorrect watcher

### DIFF
--- a/packages/datetime-picker/index.ts
+++ b/packages/datetime-picker/index.ts
@@ -52,7 +52,7 @@ VantComponent({
     ...pickerProps,
     value: {
       type: null,
-      observer: 'updateValue',
+      observer: 'updateValueNotEmit',
     },
     filter: null,
     type: {
@@ -114,6 +114,17 @@ VantComponent({
         this.updateColumnValue(val).then(() => {
           this.$emit('input', val);
         });
+      } else {
+        this.updateColumns();
+      }
+    },
+    
+    updateValueNotEmit() {
+      const { data } = this;
+      const val = this.correctValue(data.value);
+      const isEqual = val === data.innerValue;
+      if (!isEqual) {
+        this.updateColumnValue(val);
       } else {
         this.updateColumns();
       }


### PR DESCRIPTION
监听父组件的变化后不需要再 $emit，[https://github.com/youzan/vant-weapp/issues/3232](https://github.com/youzan/vant-weapp/issues/3232)