### PR TITLE
fix(calendar): fix custom color for same-day button

### DIFF
--- a/packages/calendar/components/month/index.wxs
+++ b/packages/calendar/components/month/index.wxs
@@ -23,6 +23,7 @@ function getDayStyle(type, index, date, rowHeight, color) {
     if (
       type === 'start' ||
       type === 'end' ||
+      type === 'start-end' ||
       type === 'multiple-selected' ||
       type === 'multiple-middle'
     ) {


### PR DESCRIPTION
#4162

自定义颜色未能覆盖：`allow-same-day` 开启时，选中同一天时的按钮颜色。

正常的效果
<img width="381" alt="1" src="https://user-images.githubusercontent.com/117487/117634563-9c078b80-b1b1-11eb-9e9a-54e005ee7191.png">

未覆盖到的效果
<img width="376" alt="3" src="https://user-images.githubusercontent.com/117487/117634501-8c884280-b1b1-11eb-9dec-1b5323be235c.png">

Bug 复现：
1. 使用默认的 ”自定义颜色“ 示例
1. 开启 `allow-same-day` 选项
1. 选中同一天后，颜色还是默认色，而不是覆盖的自定义颜色；而其他天数均正常

此 PR 实现的效果：
<img width="373" alt="2" src="https://user-images.githubusercontent.com/117487/117634635-b17cb580-b1b1-11eb-923f-5bc718df3298.png">


