### PR TITLE
fix(requestAnimationFrame): use nextTick in devtool

### DIFF
--- a/packages/common/utils.ts
+++ b/packages/common/utils.ts
@@ -37,9 +37,9 @@ export function requestAnimationFrame(cb: () => void) {
   const systemInfo = getSystemInfoSync();
 
   if (systemInfo.platform === 'devtools') {
-    return setTimeout(() => {
+    return nextTick(() => {
       cb();
-    }, 1000 / 30);
+    });
   }
 
   return wx


### PR DESCRIPTION
#4202 

- 开发者工具下，tabs 100个，active直接设置到最后，的确会复现问题
- 真机环境下，无法复现

唯一的区别是在使用utils/requestAnimationFrame时，实现方式不同，原先是判断如果在开发环境devtools则用setTimeout实现

