### PR TITLE
fix(button): 修复type为getUserInfo且wx.getUserProfile可用时，lang参数无效问题

### DIFF
--- a/packages/button/index.ts
+++ b/packages/button/index.ts
@@ -56,11 +56,12 @@ VantComponent({
     onClick(event: WechatMiniprogram.TouchEvent) {
       this.$emit('click', event);
 
-      const { canIUseGetUserProfile, openType, getUserProfileDesc } = this.data;
+      const { canIUseGetUserProfile, openType, getUserProfileDesc, lang } = this.data;
 
       if (openType === 'getUserInfo' && canIUseGetUserProfile) {
         wx.getUserProfile({
           desc: getUserProfileDesc || '  ',
+          lang: lang || 'en',
           complete: (userProfile) => {
             this.$emit('getuserinfo', userProfile);
           },


### PR DESCRIPTION
Button 组件获取微信用户信息时，type 属性 为 getUserInfo 并且 wx.getUserProfile 可用时，设置 lang 属性无效，获取到的用户信息一直为英文。