### PR TITLE
fix(tabs): correct active styles when match by name

### DIFF
--- a/packages/tabs/index.ts
+++ b/packages/tabs/index.ts
@@ -49,10 +49,6 @@ VantComponent({
       type: null,
       value: 0,
       observer(name) {
-        if (!this.skipInit) {
-          this.skipInit = true;
-        }
-
         if (name !== this.getCurrentName()) {
           this.setCurrentIndexByName(name);
         }
@@ -110,10 +106,8 @@ VantComponent({
         container: () => this.createSelectorQuery().select('.van-tabs'),
       });
 
-      if (!this.skipInit) {
-        this.resize();
-        this.scrollIntoView();
-      }
+      this.resize();
+      this.scrollIntoView();
     });
   },
 


### PR DESCRIPTION
[fix(4249)](https://github.com/youzan/vant-weapp/issues/4249)

修复 Tab 标签页下划线显示不正常问题