### PR TITLE
fix(Rate): adjust css varibles

### DIFF
--- a/example/pages/rate/index.js
+++ b/example/pages/rate/index.js
@@ -9,6 +9,7 @@ Page({
     value4: 2.5,
     value5: 4,
     value6: 3,
+    value7: 3.3,
     value8: 2,
   },
 

--- a/example/pages/rate/index.js
+++ b/example/pages/rate/index.js
@@ -1,4 +1,5 @@
 import Page from '../../common/page';
+import Toast from '../../dist/toast/toast';
 
 Page({
   data: {
@@ -8,5 +9,11 @@ Page({
     value4: 2.5,
     value5: 4,
     value6: 3,
+    value8: 2,
+  },
+
+  onChange(event) {
+    const value = event.detail;
+    Toast(`当前值：${value}`);
   },
 });

--- a/example/pages/rate/index.wxml
+++ b/example/pages/rate/index.wxml
@@ -19,9 +19,9 @@
     custom-class="rate-position"
     model:value="{{ value3 }}"
     size="{{ 25 }}"
-    color="#ee0a24"
-    void-color="#eee"
+    color="#ffd21e"
     void-icon="star"
+    void-color="#eee"
   />
 </demo-block>
 
@@ -60,3 +60,13 @@
     readonly
   />
 </demo-block>
+
+<demo-block title="监听 change 事件">
+  <van-rate
+    custom-class="rate-position"
+    value="{{ value8 }}"
+    bind:change="onChange"
+  />
+</demo-block>
+
+<van-toast id="van-toast" />

--- a/example/pages/rate/index.wxml
+++ b/example/pages/rate/index.wxml
@@ -61,6 +61,15 @@
   />
 </demo-block>
 
+<demo-block title="只读状态小数显示">
+  <van-rate
+    custom-class="rate-position"
+    value="{{ value7 }}"
+    readonly
+    allow-half
+  />
+</demo-block>
+
 <demo-block title="监听 change 事件">
   <van-rate
     custom-class="rate-position"

--- a/packages/common/style/var.less
+++ b/packages/common/style/var.less
@@ -387,6 +387,9 @@
 // Rate
 @rate-horizontal-padding: 2px;
 @rate-icon-size: 20px;
+@rate-icon-void-color: @gray-5;
+@rate-icon-full-color: @red;
+@rate-icon-disabled-color: @gray-5;
 
 // Switch
 @switch-width: 2em;

--- a/packages/rate/README.md
+++ b/packages/rate/README.md
@@ -100,6 +100,14 @@ Page({
 <van-rate readonly value="{{ value }}" bind:change="onChange" />
 ```
 
+### 只读状态小数显示
+
+设置 `readonly` 和 `allow-half` 属性后，Rate 组件可以展示任意小数结果。
+
+```html
+<van-rate value="{{ value }}" readonly allow-half />
+```
+
 ### 监听 change 事件
 
 评分变化时，会触发 `change` 事件。

--- a/packages/rate/README.md
+++ b/packages/rate/README.md
@@ -74,6 +74,14 @@ Page({
 />
 ```
 
+```javascript
+Page({
+  data: {
+    value: 2.5,
+  },
+});
+````
+
 ### 自定义数量
 
 ```html
@@ -90,6 +98,26 @@ Page({
 
 ```html
 <van-rate readonly value="{{ value }}" bind:change="onChange" />
+```
+
+### 监听 change 事件
+
+评分变化时，会触发 `change` 事件。
+
+```html
+<van-rate value="{{ value }}" bind:change="onChange" />
+```
+
+```javascript
+Page({
+  data: {
+    value: 2,
+  },
+
+  onChange(event) {
+    Toast(`当前值：${event.detail}`);
+  },
+});
 ```
 
 ## API

--- a/packages/rate/index.less
+++ b/packages/rate/index.less
@@ -19,7 +19,6 @@
     &--half {
       position: absolute;
       top: 0;
-      width: 0.5em;
       overflow: hidden;
       .theme(left, '@rate-horizontal-padding');
     }

--- a/packages/rate/index.less
+++ b/packages/rate/index.less
@@ -13,6 +13,7 @@
   &__icon {
     display: block;
     height: 1em;
+    .theme(color, '@rate-icon-void-color');
     .theme(font-size, '@rate-icon-size');
 
     &--half {
@@ -21,6 +22,14 @@
       width: 0.5em;
       overflow: hidden;
       .theme(left, '@rate-horizontal-padding');
+    }
+
+    &--full {
+      .theme(color, '@rate-icon-full-color');
+    }
+
+    &--disabled {
+      .theme(color, '@rate-icon-disabled-color');
     }
   }
 }

--- a/packages/rate/index.ts
+++ b/packages/rate/index.ts
@@ -28,10 +28,7 @@ VantComponent({
       type: String,
       value: 'star-o',
     },
-    color: {
-      type: String,
-      value: '#ffd21e',
-    },
+    color: String,
     voidColor: {
       type: String,
       value: '#c7c7c7',

--- a/packages/rate/index.wxml
+++ b/packages/rate/index.wxml
@@ -1,19 +1,20 @@
 <wxs src="../wxs/utils.wxs" module="utils" />
+<wxs src="../wxs/style.wxs" module="style" />
 
 <view
   class="van-rate custom-class"
   bind:touchmove="onTouchMove"
 >
   <view
-    class="van-rate__item"
+    class="{{ utils.bem('rate__item') }}"
     wx:for="{{ innerCountArray }}"
     wx:key="index"
-    style="padding-right: {{ index !== count - 1 ? utils.addUnit(gutter) : '' }}"
+    style="{{ style({ paddingRight: index !== count - 1 ? utils.addUnit(gutter) : null }) }}"
   >
     <van-icon
       name="{{ index + 1 <= innerValue ? icon : voidIcon }}"
-      class="van-rate__icon"
-      style="font-size: {{ utils.addUnit(size) }}"
+      class="{{ utils.bem('rate__icon', ['full']) }}"
+      style="{{ style({ fontSize: utils.addUnit(size) }) }}"
       custom-class="icon-class"
       data-score="{{ index }}"
       color="{{ disabled ? disabledColor : index + 1 <= innerValue ? color : voidColor }}"
@@ -21,10 +22,10 @@
     />
 
     <van-icon
-      wx:if="{{ allowHalf }}"
+      wx:if="{{ allowHalf && index + 0.5 >= innerValue }}"
       name="{{ index + 0.5 <= innerValue ? icon : voidIcon }}"
-      class="{{ utils.bem('rate__icon', ['half']) }}"
-      style="font-size: {{ utils.addUnit(size) }}"
+      class="{{ utils.bem('rate__icon', ['half', 'full']) }}"
+      style="{{ style({ fontSize: utils.addUnit(size) }) }}"
       custom-class="icon-class"
       data-score="{{ index - 0.5 }}"
       color="{{ disabled ? disabledColor : index + 0.5 <= innerValue ? color : voidColor }}"

--- a/packages/rate/index.wxml
+++ b/packages/rate/index.wxml
@@ -1,35 +1,34 @@
 <wxs src="../wxs/utils.wxs" module="utils" />
 <wxs src="../wxs/style.wxs" module="style" />
+<wxs src="./index.wxs" module="computed" />
 
 <view
   class="van-rate custom-class"
+  bind:touchstart="onTouchStart"
   bind:touchmove="onTouchMove"
 >
   <view
-    class="{{ utils.bem('rate__item') }}"
-    wx:for="{{ innerCountArray }}"
     wx:key="index"
-    style="{{ style({ paddingRight: index !== count - 1 ? utils.addUnit(gutter) : null }) }}"
+    class="{{ utils.bem('rate__item') }}"
+    wx:for="{{ computed.getList({ count, modelValue: innerValue, allowHalf, readonly, gutter }) }}"
+    style="{{ style(item.style) }}"
+    data-score="{{ item.score }}"
+    bind:tap="onClickItem"
   >
     <van-icon
-      name="{{ index + 1 <= innerValue ? icon : voidIcon }}"
-      class="{{ utils.bem('rate__icon', ['full']) }}"
-      style="{{ style({ fontSize: utils.addUnit(size) }) }}"
+      style="{{ style({ fontSize: utils.addUnit(size) })}}"
+      name="{{ item.isFull ? icon : voidIcon }}"
+      class="{{ utils.bem('rate__icon', { disabled, full: item.isFull }) }}"
       custom-class="icon-class"
-      data-score="{{ index }}"
-      color="{{ disabled ? disabledColor : index + 1 <= innerValue ? color : voidColor }}"
-      bind:click="onSelect"
+      color="{{ disabled ? disabledColor : item.isFull ? color : voidColor }}"
     />
-
     <van-icon
-      wx:if="{{ allowHalf && index + 0.5 >= innerValue }}"
-      name="{{ index + 0.5 <= innerValue ? icon : voidIcon }}"
-      class="{{ utils.bem('rate__icon', ['half', 'full']) }}"
-      style="{{ style({ fontSize: utils.addUnit(size) }) }}"
+      wx:if="{{ item.renderHalf }}"
+      style="{{ style({ fontSize: utils.addUnit(size), width: item.value + 'em' })}}"
+      name="{{ item.isVoid ? voidIcon : icon }}"
+      class="{{ utils.bem('rate__icon', ['half', { disabled, full: !item.isVoid }])}}"
+      color="{{ disabled ? disabledColor : isVoid ? voidColor : color }}"
       custom-class="icon-class"
-      data-score="{{ index - 0.5 }}"
-      color="{{ disabled ? disabledColor : index + 0.5 <= innerValue ? color : voidColor }}"
-      bind:click="onSelect"
     />
   </view>
 </view>

--- a/packages/rate/index.wxs
+++ b/packages/rate/index.wxs
@@ -1,0 +1,62 @@
+/* eslint-disable */
+function getRateStatus(
+  value,
+  index,
+  allowHalf,
+  readonly
+) {
+  if (value >= index) {
+    return { status: 'full', value: 1 };
+  }
+
+  if (value + 0.5 >= index && allowHalf && !readonly) {
+    return { status: 'half', value: 0.5 };
+  }
+
+  if (value + 1 >= index && allowHalf && readonly) {
+    var cardinal = Math.pow(10, 10);
+    return {
+      status: 'half',
+      value: Math.round((value - index + 1) * cardinal) / cardinal,
+    };
+  }
+
+  return { status: 'void', value: 0 };
+}
+
+function getList(options) {
+  var count = options.count;
+  var modelValue = options.modelValue;
+  var allowHalf = options.allowHalf;
+  var readonly = options.readonly;
+  var gutter = options.gutter;
+  var list = [];
+  for (var i = 0; i < count; i++) {
+    var score = i + 1;
+    var item = getRateStatus(
+      modelValue,
+      score,
+      allowHalf,
+      readonly
+    );
+
+    item.score = score;
+    item.isFull = item.status === 'full';
+    item.isVoid = item.status === 'void';
+    item.renderHalf = allowHalf && item.value > 0 && item.value < 1;
+
+    item.style = {};
+    if (gutter && score !== +count) {
+      item.style = {
+        paddingRight: addUnit(gutter),
+      };
+    }
+
+    list.push(item);
+  }
+  return list;
+}
+
+module.exports = {
+  getList: getList,
+};


### PR DESCRIPTION
- 使用bem定义class
- 默认色从黄色改成红色，与vant同步
- 新增 `--rate-icon-void-color` `--rate-icon-full-color` `--rate-icon-disabled-color` 三个css变量使其能支持ConfigProvider
- 调整默认行为，加入star为full，则隐藏半星icon，这与vant相同
- color prop取消默认颜色
- 新增「监听 change 事件」demo
- 依赖 #4281 中的驼峰法使用style attr，避免出现 `<van-icon style="size: ;" />` 这样的无效style