### PR TITLE
fix(griditem): set icon prefix to 'van-icon'

### DIFF
--- a/packages/grid-item/index.ts
+++ b/packages/grid-item/index.ts
@@ -12,7 +12,10 @@ VantComponent({
   props: {
     icon: String,
     iconColor: String,
-    iconPrefix: String,
+    iconPrefix: {
+      type: String,
+      value: 'van-icon',
+    },
     dot: Boolean,
     info: null,
     badge: null,


### PR DESCRIPTION
close #4317 