### PR TITLE
perf: 不再兼容 iOS8

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,6 @@
   "browserslist": [
     "Chrome >= 53",
     "ChromeAndroid >= 53",
-    "iOS >= 8"
+    "iOS >= 9"
   ]
 }


### PR DESCRIPTION
微信在 2018 年底就不再支持 iOS8 了，所以 vant-weapp 也移除对 iOS8 的支持，可以有效减少包体积