### PR TITLE
fix(Sticky): Cannot read property 'top' of null

### DIFF
--- a/packages/calendar/index.ts
+++ b/packages/calendar/index.ts
@@ -201,11 +201,11 @@ VantComponent({
         const start = this.limitDateRange(
           startDay || now,
           minDate,
-          getPrevDay(maxDate).getTime()
+          getPrevDay(new Date(maxDate)).getTime()
         );
         const end = this.limitDateRange(
           endDay || now,
-          getNextDay(minDate).getTime()
+          getNextDay(new Date(minDate)).getTime()
         );
         return [start, end];
       }

--- a/packages/sticky/index.ts
+++ b/packages/sticky/index.ts
@@ -89,7 +89,10 @@ VantComponent({
       }
 
       getRect(this, ROOT_ELEMENT).then((root) => {
-        if (offsetTop >= root?.top) {
+        if (!root) {
+          return;
+        }
+        if (offsetTop >= root.top) {
           this.setDataAfterDiff({ fixed: true, height: root.height });
           this.transform = 0;
         } else {

--- a/packages/sticky/index.ts
+++ b/packages/sticky/index.ts
@@ -89,7 +89,7 @@ VantComponent({
       }
 
       getRect(this, ROOT_ELEMENT).then((root) => {
-        if (offsetTop >= root?.top) {
+        if (offsetTop >= root.top) {
           this.setDataAfterDiff({ fixed: true, height: root.height });
           this.transform = 0;
         } else {

--- a/packages/sticky/index.ts
+++ b/packages/sticky/index.ts
@@ -89,7 +89,7 @@ VantComponent({
       }
 
       getRect(this, ROOT_ELEMENT).then((root) => {
-        if (offsetTop >= root.top) {
+        if (offsetTop >= root?.top) {
           this.setDataAfterDiff({ fixed: true, height: root.height });
           this.transform = 0;
         } else {

--- a/packages/sticky/index.ts
+++ b/packages/sticky/index.ts
@@ -1,5 +1,6 @@
 import { getRect } from '../common/utils';
 import { VantComponent } from '../common/component';
+import { isDef } from '../common/validator';
 import { pageScrollMixin } from '../mixins/page-scroll';
 
 const ROOT_ELEMENT = '.van-sticky';
@@ -89,7 +90,7 @@ VantComponent({
       }
 
       getRect(this, ROOT_ELEMENT).then((root) => {
-        if (!root) {
+        if (!isDef(root)) {
           return;
         }
         if (offsetTop >= root.top) {


### PR DESCRIPTION
#4148 

原因：
由于 `offsetTop` 等属性改变时会触发 `onScroll`，页面在完成渲染之前 `getRect` 无法通过 `this` 上下文查询到正确的 `root`