### PR TITLE
fix(Tab): fix init position incorrect

### DIFF
--- a/packages/tabs/index.ts
+++ b/packages/tabs/index.ts
@@ -49,10 +49,6 @@ VantComponent({
       type: null,
       value: 0,
       observer(name) {
-        if (!this.skipInit) {
-          this.skipInit = true;
-        }
-
         if (name !== this.getCurrentName()) {
           this.setCurrentIndexByName(name);
         }
@@ -98,7 +94,7 @@ VantComponent({
     scrollLeft: 0,
     scrollable: false,
     currentIndex: 0,
-    container: (null as unknown) as () => WechatMiniprogram.NodesRef,
+    container: null as unknown as () => WechatMiniprogram.NodesRef,
     skipTransition: true,
     scrollWithAnimation: false,
     lineOffsetLeft: 0,
@@ -110,10 +106,8 @@ VantComponent({
         container: () => this.createSelectorQuery().select('.van-tabs'),
       });
 
-      if (!this.skipInit) {
-        this.resize();
-        this.scrollIntoView();
-      }
+      this.resize();
+      this.scrollIntoView();
     });
   },
 

--- a/packages/tabs/index.ts
+++ b/packages/tabs/index.ts
@@ -94,7 +94,7 @@ VantComponent({
     scrollLeft: 0,
     scrollable: false,
     currentIndex: 0,
-    container: null as unknown as () => WechatMiniprogram.NodesRef,
+    container: (null as unknown) as () => WechatMiniprogram.NodesRef,
     skipTransition: true,
     scrollWithAnimation: false,
     lineOffsetLeft: 0,


### PR DESCRIPTION
#4513 
历史issue：#4202
关联PR：#4221 #4263
`skipInit` 似乎在引发一些奇怪的问题（目前issues中好像还有几个tab的定位问题，可能都跟这个有关），暂时先去掉该值，目前测试两个历史case成功。


### 测试用例

```html
<van-tabs active="{{ 16 }}" bind:change="onChange">
  <van-tab
    wx:for="{{ 19 }}"
    wx:key="index"
    title="{{ '标签 ' + item }}"
  >
    <view class="content">
      {{ '内容' + item }}
    </view>
  </van-tab>
</van-tabs>
```

```html
<van-tabs active="{{ 88 }}" bind:change="onChange">
  <van-tab
    wx:for="{{ 100 }}"
    wx:key="index"
    title="{{ '标签 ' + item }}"
  >
    <view class="content">
      {{ '内容' + item }}
    </view>
  </van-tab>
</van-tabs>
```
