### PR TITLE
fix(Slider): fix click invalid with vertical props

### DIFF
--- a/example/pages/slider/index.wxml
+++ b/example/pages/slider/index.wxml
@@ -67,7 +67,7 @@
 <demo-block title="垂直方向">
   <view style="height: 150px; padding-left: 30px;">
     <van-slider
-      value="{{ currentValue }}"
+      value="{{ 50 }}"
       vertical
       custom-class="slider"
       bind:change="onChange"

--- a/packages/slider/index.ts
+++ b/packages/slider/index.ts
@@ -109,9 +109,10 @@ VantComponent({
 
       getRect(this, '.van-slider').then((rect) => {
         const { vertical } = this.data;
+        const touch = event.touches[0];
         const delta = vertical
-          ? event.detail.y - rect.top
-          : event.detail.x - rect.left;
+          ? touch.clientY - rect.top
+          : touch.clientX - rect.left;
         const total = vertical ? rect.height : rect.width;
         const value = Number(min) + (delta / total) * this.getRange();
 
@@ -160,7 +161,7 @@ VantComponent({
       this.setData({
         wrapperStyle: `
           background: ${this.data.inactiveColor || ''};
-          ${mainAxis}: ${addUnit(this.data.barHeight) || ''};
+          ${vertical ? 'width' : 'height'}: ${addUnit(this.data.barHeight) || ''};
         `,
         barStyle: `
           ${mainAxis}: ${this.calcMainAxis()};


### PR DESCRIPTION
#4486 

问题一：`wrapperStyle` 和 `barStyle` 判断 width和height应该是相反的，实际是写成了同样的判断逻辑

问题二：onClick `event.detail.y` 是 `scrollTop` 值，而 `getRect` 提供的 `top` 是距离屏幕高度，实际应该将 `event.detail.y` 调整成 `event.touches[0].clientY`。测试时把example中的其他case删了，只保留一个vertical的是可以的。。。结果没测出来