### PR TITLE
fix(Dialog): Solutions to keep the content within the container

### DIFF
--- a/packages/dialog/index.less
+++ b/packages/dialog/index.less
@@ -75,6 +75,7 @@
 
   &__button {
     flex: 1;
+    width: 0;
   }
 
   &__confirm,


### PR DESCRIPTION
**设备**
iPhone

**VantWeapp 版本**
1.9.1

**基础库版本**
2.20.0

**问题描述**
调用 Dialog.confirm flex布局子元素宽度超出父元素问题 
问题只在使用 小程序基础库 v2.8.3 以上的小程序上出现

**原因分析**
应该是微信浏览器提供的user agent stylesheet的button 默认width 导致flex子元素宽度过大 超出flex父元素时，设置flex:1并不能限制flex子元素的尺寸

**解决方案**
限制子元素原本宽度，设置width属性 ，强行设置原本宽度为0，让子元素盒模型宽度完全由flex: 1这个属性来分配