### PR TITLE
fix(Collapse): animate invalid on multi clicks

### DIFF
--- a/packages/collapse-item/animate.ts
+++ b/packages/collapse-item/animate.ts
@@ -1,42 +1,4 @@
-import { canIUseAnimate } from '../common/version';
 import { getRect } from '../common/utils';
-
-function useAnimate(
-  context: WechatMiniprogram.Component.TrivialInstance,
-  expanded: boolean,
-  mounted: boolean,
-  height: number
-) {
-  const selector = '.van-collapse-item__wrapper';
-  if (expanded) {
-    context.animate(
-      selector,
-      [
-        { height: 0, ease: 'ease-in-out', offset: 0 },
-        { height: `${height}px`, ease: 'ease-in-out', offset: 1 },
-        { height: `auto`, ease: 'ease-in-out', offset: 1 },
-      ],
-      mounted ? 300 : 0,
-      () => {
-        context.clearAnimation(selector);
-      }
-    );
-
-    return;
-  }
-
-  context.animate(
-    selector,
-    [
-      { height: `${height}px`, ease: 'ease-in-out', offset: 0 },
-      { height: 0, ease: 'ease-in-out', offset: 1 },
-    ],
-    300,
-    () => {
-      context.clearAnimation(selector);
-    }
-  );
-}
 
 function useAnimation(
   context: WechatMiniprogram.Component.TrivialInstance,
@@ -86,8 +48,6 @@ export function setContentAnimate(
   getRect(context, '.van-collapse-item__content')
     .then((rect) => rect.height)
     .then((height: number) => {
-      canIUseAnimate()
-        ? useAnimate(context, expanded, mounted, height)
-        : useAnimation(context, expanded, mounted, height);
+      useAnimation(context, expanded, mounted, height);
     });
 }


### PR DESCRIPTION
无反应
#4422
#4068

缓慢
#4523
#4111

### 问题描述
此类问题应该只在使用 小程序基础库 `v2.9.0` 以上的小程序上出现

### 原因分析
应该是微信新提供的 `this.animate` 和旧版的 `wx.createAnimation` 存在差异。
主要差异应该是 `this.animate` 内部应该是队列形式，必须要执行完上一个动画才可以，而 `wx.createAnimation` 实际是生成动画样式，然后塞到dom中，可以进行强行中断当前动画塞入新动画。

### 其他尝试
- 尝试在使用 `this.animate` 时判断当前是否正在进行动画，如果有则调用 `this.clearAnimation`。但是效果并不理想，会有闪烁出现

### 猜测的结论
所以像这种快速点击（多次中断当前动画）的场景 `this.animate` 可能无法满足