### PR TITLE
index-bar 在wx:if为false时， 抛异常

### DIFF
--- a/packages/index-bar/index.ts
+++ b/packages/index-bar/index.ts
@@ -101,6 +101,9 @@ VantComponent({
 
     setListRect() {
       return getRect(this, '.van-index-bar').then((rect) => {
+        if (!isDef(rect)) {
+          return;
+        }
         Object.assign(this, {
           height: rect.height,
           top: rect.top + this.scrollTop,


### PR DESCRIPTION
fix(IndexBar): When used with wx:if, wx:if is false and throws an exception


