### PR TITLE
fix(Toast): fix classname 'vant-toast-text'

### DIFF
--- a/packages/toast/index.wxml
+++ b/packages/toast/index.wxml
@@ -10,7 +10,7 @@
   custom-class="van-toast__container"
 >
   <view
-    class="van-toast van-toast--{{ type === 'icon' ? 'icon' : 'text' }} van-toast--{{ position }}"
+    class="van-toast van-toast--{{ (type === 'text' || type === 'html') ? 'text' : 'icon' }} van-toast--{{ position }}"
     catch:touchmove="noop"
   >
     <!-- text only -->


### PR DESCRIPTION
toast组件不存在icon的type值，但wxml中使用了该值做判断
