### PR TITLE
fix(Toast): fix style incorrect

### DIFF
--- a/packages/toast/index.wxml
+++ b/packages/toast/index.wxml
@@ -10,7 +10,7 @@
   custom-class="van-toast__container"
 >
   <view
-    class="van-toast van-toast--{{ type === 'icon' ? 'icon' : 'text' }} van-toast--{{ position }}"
+    class="van-toast van-toast--{{ (type === 'text' || type === 'html') ? 'text' : 'icon' }} van-toast--{{ position }}"
     catch:touchmove="noop"
   >
     <!-- text only -->


### PR DESCRIPTION
修复当 `type` 为 `success` `error` 时toast样式不正确