### PR TITLE
fix(circle): use fixed width and height for outer view of circle

### DIFF
--- a/dist/circle/index.wxml
+++ b/dist/circle/index.wxml
@@ -1,6 +1,6 @@
 <wxs src="../wxs/utils.wxs" module="utils" />
 
-<view class="van-circle">
+<view style="width: {{ utils.addUnit(size) }};height:{{ utils.addUnit(size) }}" class="van-circle">
   <canvas class="van-circle__canvas" type="{{ type }}" style="width: {{ utils.addUnit(size) }};height:{{ utils.addUnit(size) }}" id="van-circle" canvas-id="van-circle"></canvas>
   <view wx:if="{{ !text }}" class="van-circle__text">
     <slot></slot>

--- a/lib/circle/index.wxml
+++ b/lib/circle/index.wxml
@@ -1,6 +1,6 @@
 <wxs src="../wxs/utils.wxs" module="utils" />
 
-<view class="van-circle">
+<view style="width: {{ utils.addUnit(size) }};height:{{ utils.addUnit(size) }}" class="van-circle">
   <canvas class="van-circle__canvas" type="{{ type }}" style="width: {{ utils.addUnit(size) }};height:{{ utils.addUnit(size) }}" id="van-circle" canvas-id="van-circle"></canvas>
   <view wx:if="{{ !text }}" class="van-circle__text">
     <slot></slot>


### PR DESCRIPTION
[issues 4681](https://github.com/youzan/vant-weapp/issues/4681)

当 js 通过 setData 更新数据（圆环进度）涉及到 vant-circle 的时候会由于渲染延时引发 view 父组件不能及时计算正确长宽引发依赖于他计算位置的其余组件渲染错位。
已经提交了 bug report。
根据设计，作为 inline-block 这种情况会很常见。
希望能修复。
在模拟器没有问题，真机测试检测到这个问题，可以通过给组件内部实现的 canvas 外的 view 容器添加一个长宽限定解决问题。
重现时 van-circle 大小设置为小于100 如 80时会出现。


### Pull Request 标题

fix(circle): use fixed width and height for outer view of circle

### 类型:

- fix
