### PR TITLE
fix(datetime-picker ): not smooth in Android

### DIFF
--- a/packages/picker-column/index.ts
+++ b/packages/picker-column/index.ts
@@ -46,6 +46,12 @@ VantComponent({
   },
 
   methods: {
+    promiseSetData(data: any) {
+      return new Promise<void>((resolve) => {
+        this.setData(data, resolve);
+      });
+    },
+
     getCount() {
       return this.data.options.length;
     },
@@ -119,7 +125,7 @@ VantComponent({
       const offset = -index * data.itemHeight;
 
       if (index !== data.currentIndex) {
-        return this.set({ offset, currentIndex: index }).then(() => {
+        return this.promiseSetData({ offset, currentIndex: index }).then(() => {
           userAction && this.$emit('change', index);
         });
       }


### PR DESCRIPTION
发现主要是set方法调用的wx.nextTick()引起的延迟，调整为微信官方推荐的this.setData(obj, callback)模式实现