### PR TITLE
fix(ShareSheet): the <button> should wrap the text

### DIFF
--- a/packages/share-sheet/options.wxml
+++ b/packages/share-sheet/options.wxml
@@ -10,11 +10,11 @@
     bindtap="onSelect"
   >
     <button class="van-share-sheet__button" open-type="{{ item.openType }}">
-      <image src="{{ computed.getIconURL(item.icon) }}" class="van-share-sheet__icon" />
+      <image src="{{ computed.getIconURL(item.icon) }}" class="van-share-sheet__icon" /> 
+      <view wx:if="{{ item.name }}" class="van-share-sheet__name">{{ item.name }}</view>
+      <view wx:if="{{ item.description }}" class="van-share-sheet__option-description">
+        {{ item.description }}
+      </view>
     </button>
-    <view wx:if="{{ item.name }}" class="van-share-sheet__name">{{ item.name }}</view>
-    <view wx:if="{{ item.description }}" class="van-share-sheet__option-description">
-      {{ item.description }}
-    </view>
   </view>
 </view>


### PR DESCRIPTION
ShareSheet 分享面板的分享按钮没包围文本，导致点击到文本时弹框关闭但没触发用户分享