### PR TITLE
docs(Toast): add custom icon or image usage

### DIFF
--- a/packages/button/index.wxml
+++ b/packages/button/index.wxml
@@ -19,6 +19,7 @@
   app-parameter="{{ appParameter }}"
   aria-label="{{ ariaLabel }}"
   bindtap="{{ disabled || loading ? '' : 'onClick' }}"
+  disabled="{{ disabled }}"
   bindgetuserinfo="onGetUserInfo"
   bindcontact="onContact"
   bindgetphonenumber="onGetPhoneNumber"

--- a/packages/toast/README.md
+++ b/packages/toast/README.md
@@ -111,7 +111,7 @@ Toast({
 
 | 参数 | 说明 | 类型 | 默认值 |
 | --- | --- | --- | --- |
-| type | 提示类型，可选值为 `loading` `success` `fail` `html` | _string_ | `text` |
+| type | 提示类型，可选值为 `loading` `success` `fail` `html`；若要使用自定义图标/图片，可将 type 值设置为图标/图片的地址 | _string_ | `text` |
 | position | 位置，可选值为 `top` `middle` `bottom` | _string_ | `middle` |
 | message | 内容 | _string_ | `''` |
 | mask | 是否显示遮罩层 | _boolean_ | `false` |


### PR DESCRIPTION
1. add custom icon or image usage in doc.
2. fix button disabled prop doesn't work