### PR TITLE
feat(van-uploader) add preview-size prop type

### DIFF
--- a/packages/uploader/index.wxs
+++ b/packages/uploader/index.wxs
@@ -3,7 +3,10 @@ var style = require('../wxs/style.wxs');
 var addUnit = require('../wxs/add-unit.wxs');
 
 function sizeStyle(data) {
-  return style({
+  return "Array" === data.previewSize.constructor ? style({
+    width: addUnit(data.previewSize[0]),
+    height: addUnit(data.previewSize[1]),
+  }) : style({
     width: addUnit(data.previewSize),
     height: addUnit(data.previewSize),
   });


### PR DESCRIPTION
van-uploader 组件新增preview-size属性类型支持Array,String[]或者String,实现自定义宽高

example:
```
<van-uploader file-list="{{ fileList }}" bind:after-read="afterRead" preview-size="{{[450,250]}}" />
<van-uploader file-list="{{ fileList }}" bind:after-read="afterRead" preview-size="100" />
```