### PR TITLE
fix(Calendar): getDay 和 getUTCDay 有时间差，导致星期错位

### DIFF
--- a/lib/calendar/components/month/index.wxs
+++ b/lib/calendar/components/month/index.wxs
@@ -9,7 +9,7 @@ var ROW_HEIGHT = 64;
 
 function getDayStyle(type, index, date, rowHeight, color, firstDayOfWeek) {
   var style = [];
-  var current = getDate(date).getDay() || 7;
+  var current = getDate(date).getUTCDay() || 7;
   var offset = current < firstDayOfWeek ? (7 - firstDayOfWeek + current) :
                current === 7 && firstDayOfWeek === 0 ? 0 :
                (current - firstDayOfWeek);


### PR DESCRIPTION
https://github.com/youzan/vant-weapp/issues/4756