### PR TITLE
fix(NavBar): 修复因box-sizing:border-box导致导航栏高度不正确问题

### DIFF
--- a/packages/nav-bar/index.less
+++ b/packages/nav-bar/index.less
@@ -7,7 +7,8 @@
   height: var(--nav-bar-height, @nav-bar-height);
   line-height: var(--nav-bar-height, @nav-bar-height);
   background-color: var(--nav-bar-background-color, @nav-bar-background-color);
-
+  box-sizing: content-box;
+  
   &__content {
     position: relative;
     height: 100%;

--- a/packages/nav-bar/index.wxml
+++ b/packages/nav-bar/index.wxml
@@ -7,6 +7,7 @@
   class="{{ utils.bem('nav-bar', { fixed }) }} custom-class {{ border ? 'van-hairline--bottom' : '' }}"
   style="{{ computed.barStyle({ zIndex, statusBarHeight, safeAreaInsetTop }) }}; {{ customStyle }}"
 >
+
   <view class="van-nav-bar__content">
     <view class="van-nav-bar__left" bind:tap="onClickLeft">
       <block wx:if="{{ leftArrow || leftText }}">


### PR DESCRIPTION
## 说明
当全局设置 `view{ box-sizing: border-box;}`时，NavBar会出现高度不正确情况。

#4862 应该也是因为这个原因