### PR TITLE
fix: The input box is too fast, and the data is not updated in time, resulting in an error in obtaining data

### DIFF
--- a/packages/field/index.ts
+++ b/packages/field/index.ts
@@ -144,11 +144,8 @@ VantComponent({
 
     emitChange() {
       this.setData({ value: this.value });
-
-      nextTick(() => {
-        this.$emit('input', this.value);
-        this.$emit('change', this.value);
-      });
+      this.$emit('input', this.value);
+      this.$emit('change', this.value);
     },
 
     setShowClear() {


### PR DESCRIPTION
fix: 在模拟框内的输入框，如果输入太快，数据可能没有及时更新，导致提交时获取数据时出错；
<img width="364" alt="image" src="https://user-images.githubusercontent.com/43339400/217746951-ba9fb3bf-f4b9-4fce-ae39-5e773112ba2d.png">
