### PR TITLE
修复插件内使用van-tabs切换tab报错的问题

### DIFF
--- a/lib/common/version.js
+++ b/lib/common/version.js
@@ -1,6 +1,7 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.canIUseGetUserProfile = exports.canIUseCanvas2d = exports.canIUseNextTick = exports.canIUseGroupSetData = exports.canIUseAnimate = exports.canIUseFormFieldButton = exports.canIUseModel = void 0;
+var utils_1 = require("./utils");
 function compareVersion(v1, v2) {
     v1 = v1.split('.');
     v2 = v2.split('.');
@@ -24,7 +25,7 @@ function compareVersion(v1, v2) {
     return 0;
 }
 function gte(version) {
-  var system = wx.getSystemInfoSync();
+    var system = (0, utils_1.getSystemInfoSync)();
     return compareVersion(system.SDKVersion, version) >= 0;
 }
 function canIUseModel() {

--- a/lib/common/version.js
+++ b/lib/common/version.js
@@ -1,7 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.canIUseGetUserProfile = exports.canIUseCanvas2d = exports.canIUseNextTick = exports.canIUseGroupSetData = exports.canIUseAnimate = exports.canIUseFormFieldButton = exports.canIUseModel = void 0;
-var utils_1 = require("./utils");
 function compareVersion(v1, v2) {
     v1 = v1.split('.');
     v2 = v2.split('.');
@@ -25,7 +24,7 @@ function compareVersion(v1, v2) {
     return 0;
 }
 function gte(version) {
-    var system = (0, utils_1.getSystemInfoSync)();
+  var system = wx.getSystemInfoSync();
     return compareVersion(system.SDKVersion, version) >= 0;
 }
 function canIUseModel() {

--- a/packages/common/utils.ts
+++ b/packages/common/utils.ts
@@ -1,9 +1,5 @@
 import { isDef, isNumber, isPlainObject, isPromise } from './validator';
-import {
-  canIUseGroupSetData,
-  canIUseNextTick,
-  getSystemInfoSync,
-} from './version';
+import { canIUseGroupSetData, canIUseNextTick, getSystemInfoSync } from './version';
 
 export { isDef } from './validator';
 export { getSystemInfoSync } from './version';

--- a/packages/common/utils.ts
+++ b/packages/common/utils.ts
@@ -1,7 +1,12 @@
 import { isDef, isNumber, isPlainObject, isPromise } from './validator';
-import { canIUseGroupSetData, canIUseNextTick } from './version';
+import {
+  canIUseGroupSetData,
+  canIUseNextTick,
+  getSystemInfoSync,
+} from './version';
 
 export { isDef } from './validator';
+export { getSystemInfoSync } from './version';
 
 export function range(num: number, min: number, max: number) {
   return Math.min(Math.max(num, min), max);
@@ -15,15 +20,6 @@ export function nextTick(cb: (...args: any[]) => void) {
       cb();
     }, 1000 / 30);
   }
-}
-
-let systemInfo: WechatMiniprogram.SystemInfo;
-export function getSystemInfoSync() {
-  if (systemInfo == null) {
-    systemInfo = wx.getSystemInfoSync();
-  }
-
-  return systemInfo;
 }
 
 export function addUnit(value?: string | number): string | undefined {

--- a/packages/common/version.ts
+++ b/packages/common/version.ts
@@ -1,4 +1,11 @@
-import { getSystemInfoSync } from './utils';
+let systemInfo: WechatMiniprogram.SystemInfo;
+export function getSystemInfoSync() {
+  if (systemInfo == null) {
+    systemInfo = wx.getSystemInfoSync();
+  }
+
+  return systemInfo;
+}
 
 function compareVersion(v1, v2) {
   v1 = v1.split('.');
@@ -49,22 +56,10 @@ export function canIUseGroupSetData() {
   return gte('2.4.0');
 }
 
-/**
- *
- * wx.nextTick
- * 基础库 2.2.3 开始支持，低版本需做兼容处理。
- * 小程序插件：支持，需要小程序基础库版本不低于 2.7.1
- * 微信 Windows 版：支持
- * 微信 Mac 版：支持
- *
- * 插件内不支持调用 wx.canIUse
- */
 export function canIUseNextTick() {
   try {
     return wx.canIUse('nextTick');
-    // 小程序插件不支持 wx.canIUse
   } catch (e) {
-    // 小程序基础库版本不低于2.7.1插件可以调用wx.nextTick
     return gte('2.7.1');
   }
 }

--- a/packages/common/version.ts
+++ b/packages/common/version.ts
@@ -49,8 +49,24 @@ export function canIUseGroupSetData() {
   return gte('2.4.0');
 }
 
+/**
+ *
+ * wx.nextTick
+ * 基础库 2.2.3 开始支持，低版本需做兼容处理。
+ * 小程序插件：支持，需要小程序基础库版本不低于 2.7.1
+ * 微信 Windows 版：支持
+ * 微信 Mac 版：支持
+ *
+ * 插件内不支持调用 wx.canIUse
+ */
 export function canIUseNextTick() {
-  return wx.canIUse('nextTick');
+  try {
+    return wx.canIUse('nextTick');
+    // 小程序插件不支持 wx.canIUse
+  } catch (e) {
+    // 小程序基础库版本不低于2.7.1插件可以调用wx.nextTick
+    return gte('2.7.1');
+  }
 }
 
 export function canIUseCanvas2d() {


### PR DESCRIPTION
### Pull Request 标题规则
bug report：https://github.com/youzan/vant-weapp/issues/5072

type(ComponentName?)：commit message

示例：

- docs: fix typo in quickstart
- 插件内使用vant-tabs切换标签时报错
- fix(Button): incorrect style
- 修复utils和version循环require的问题
- 修复插件无法调用wx.canIUse而导致抛异常问题
