### PR TITLE
fix(stepper):修复stepper blur事件失焦时会触发change事件

### DIFF
--- a/packages/stepper/index.ts
+++ b/packages/stepper/index.ts
@@ -119,7 +119,6 @@ VantComponent({
 
     onBlur(event: WechatMiniprogram.InputBlur) {
       const value = this.format(event.detail.value);
-      this.emitChange(value);
       this.$emit('blur', {
         ...event.detail,
         value,


### PR DESCRIPTION
### 说明

当stepper组件的blur事件触发时，会将change事件一起触发，所以将onBlur函数内触发该事件的方法删除。
https://github.com/youzan/vant-weapp/issues/4876
应该就是这种情况
