### PR TITLE
fix(calendar): 修复calendar组件安全区域传参未传递给popup组件的问题

### DIFF
--- a/dist/calendar/index.wxml
+++ b/dist/calendar/index.wxml
@@ -12,6 +12,7 @@
   position="{{ position }}"
   closeable="{{ showTitle || showSubtitle }}"
   close-on-click-overlay="{{ closeOnClickOverlay }}"
+  safe-area-inset-bottom="{{ safeAreaInsetBottom }}"
   bind:enter="onOpen"
   bind:close="onClose"
   bind:after-enter="onOpened"

--- a/lib/calendar/index.wxml
+++ b/lib/calendar/index.wxml
@@ -12,6 +12,7 @@
   position="{{ position }}"
   closeable="{{ showTitle || showSubtitle }}"
   close-on-click-overlay="{{ closeOnClickOverlay }}"
+  safe-area-inset-bottom="{{ safeAreaInsetBottom }}"
   bind:enter="onOpen"
   bind:close="onClose"
   bind:after-enter="onOpened"

--- a/packages/calendar/index.wxml
+++ b/packages/calendar/index.wxml
@@ -12,6 +12,7 @@
   position="{{ position }}"
   closeable="{{ showTitle || showSubtitle }}"
   close-on-click-overlay="{{ closeOnClickOverlay }}"
+  safe-area-inset-bottom="{{ safeAreaInsetBottom }}"
   bind:enter="onOpen"
   bind:close="onClose"
   bind:after-enter="onOpened"


### PR DESCRIPTION
fix(calendar)：修复calendar组件安全区域传参未传递给popup组件的问题

官方文档中标明calendar组件可通过safe-area-inset-bottom来开启安全区域适配, 使用过程中发现以下问题:
1. 关闭安全区域适配时不生效, 通过查看发现是因为安全区域的适配是通过popup组件实现的.
2. 传递给calendar组件的safe-area-inset-bottom参数并未传递给popup组件,导致popup组件一直使用默认的true来开启安全区域适配