### PR TITLE
fix(overlay && transition): 修复组件上添加catch:touchmove不生效的问题

### DIFF
--- a/packages/overlay/index.ts
+++ b/packages/overlay/index.ts
@@ -22,8 +22,5 @@ VantComponent({
     onClick() {
       this.$emit('click');
     },
-
-    // for prevent touchmove
-    noop() {},
   },
 });

--- a/packages/overlay/index.wxml
+++ b/packages/overlay/index.wxml
@@ -1,21 +1,10 @@
 <van-transition
-  wx:if="{{ lockScroll }}"
   show="{{ show }}"
   custom-class="van-overlay custom-class"
   custom-style="z-index: {{ zIndex }}; {{ customStyle }}"
   duration="{{ duration }}"
   bind:tap="onClick"
-  catch:touchmove="noop"
->
-  <slot></slot>
-</van-transition>
-<van-transition
-  wx:else
-  show="{{ show }}"
-  custom-class="van-overlay custom-class"
-  custom-style="z-index: {{ zIndex }}; {{ customStyle }}"
-  duration="{{ duration }}"
-  bind:tap="onClick"
+  lock-scroll="{{ lockScroll }}"
 >
   <slot></slot>
 </van-transition>

--- a/packages/transition/index.ts
+++ b/packages/transition/index.ts
@@ -12,4 +12,16 @@ VantComponent({
   ],
 
   mixins: [transition(true)],
+
+  props: {
+    lockScroll: {
+      type: Boolean,
+      value: false,
+    },
+  },
+
+  methods: {
+    // for prevent touchmove
+    noop() {},
+  },
 });

--- a/packages/transition/index.wxml
+++ b/packages/transition/index.wxml
@@ -1,7 +1,17 @@
 <wxs src="./index.wxs" module="computed" />
 
 <view
-  wx:if="{{ inited }}"
+  wx:if="{{ inited && lockScroll }}"
+  class="van-transition custom-class {{ classes }}"
+  style="{{ computed.rootStyle({ currentDuration, display, customStyle }) }}"
+  bind:transitionend="onTransitionEnd"
+  catch:touchmove="noop"
+>
+  <slot />
+</view>
+
+<view
+  wx:if="{{ inited && !lockScroll }}"
   class="van-transition custom-class {{ classes }}"
   style="{{ computed.rootStyle({ currentDuration, display, customStyle }) }}"
   bind:transitionend="onTransitionEnd"


### PR DESCRIPTION
fix(overlay && transition): 修复组件上添加catch:touchmove不生效的问题

在uniapp中使用vant-weapp库时, 发现以下问题, overlay组件的背景滚动锁定不生效, 经过个人测试发现以下问题:
1. 在组件上添加catch:touchmove来控制背景滚动锁定时不生效, 在普通元素上会有效
2. overlay组件内部是transition组件, vant中将catch:touchmove添加到该组件上
3. 此次修改是将overlay的lockScroll参数传递给transition组件, 在transition组件中判断并渲染, 并且去除了overlay组件中的判断渲染逻辑.