### PR TITLE
fix(cascader): 修复cascader组件onClickTab事件没有同步activeTab的值导致选择异常的问题

### DIFF
--- a/packages/cascader/index.ts
+++ b/packages/cascader/index.ts
@@ -193,6 +193,9 @@ VantComponent({
     onClickTab(e) {
       const { index: tabIndex, title } = e.detail;
       this.$emit('click-tab', { title, tabIndex });
+      this.setData({
+        activeTab: tabIndex,
+      });
     },
     // 选中
     onSelect(e) {


### PR DESCRIPTION
#5218 