### PR TITLE
fix(Rate): fix half rate height 

### DIFF
--- a/packages/rate/index.less
+++ b/packages/rate/index.less
@@ -15,7 +15,7 @@
 
   &__icon {
     display: block;
-    height: 1em;
+    height: 100%;
     color: var(--rate-icon-void-color, @rate-icon-void-color);
     font-size: var(--rate-icon-size, @rate-icon-size);
 


### PR DESCRIPTION
van-cascader  #5294 
fix : 评分组件一半时高度不正确  
问题可能原因 van-icon组件的display为inline-block color只作用于所示高度  
可以给.van-icon类 增加vertical-align: top 或者 display改成block  
或者可以给 .van-rate__icon 类的height 改成100%或者不设置height  这样改可以解决问题感觉影响面小一点 
改完后没有指定高度.van-rate容器盒子会稍微大了一点 图标的大小依旧根据传入的size决定不受影响
<img width="676" alt="image" src="https://user-images.githubusercontent.com/64689255/227875499-466a6d39-8475-4db8-8619-9d51737323c7.png">
