### PR TITLE
fix(tabs): fix tab info module unusual offset

### DIFF
--- a/packages/tabs/index.less
+++ b/packages/tabs/index.less
@@ -150,7 +150,6 @@
     &__info {
       position: relative !important;
       top: -1px !important;
-      display: inline-block;
       transform: translateX(0) !important;
     }
   }


### PR DESCRIPTION
### fix(tabs): Background offset
不用单独设置display: inline-block, 直接使用van-info默认的display: inline-flex即可。
#5318