### PR TITLE
fix(tab): fix tab height

### DIFF
--- a/packages/tabs/index.wxml
+++ b/packages/tabs/index.wxml
@@ -1,7 +1,7 @@
 <wxs src="../wxs/utils.wxs" module="utils" />
 <wxs src="./index.wxs" module="computed" />
 
-<view class="custom-class {{ utils.bem('tabs', [type]) }}">
+<view class="custom-class {{ utils.bem('tabs') }}">
   <van-sticky
     disabled="{{ !sticky }}"
     z-index="{{ zIndex }}"
@@ -9,7 +9,7 @@
     container="{{ container }}"
     bind:scroll="onTouchScroll"
   >
-    <view class="{{ utils.bem('tabs__wrap', { scrollable }) }} {{ type === 'line' && border ? 'van-hairline--top-bottom' : '' }} wrap-class">
+    <view class="{{ utils.bem('tabs__wrap', { scrollable }) }} {{ type === 'line' && border ? 'van-hairline--top-bottom' : '' }} {{ utils.bem('tabs--' + type) }} wrap-class">
       <slot name="nav-left" />
 
       <scroll-view

--- a/packages/tabs/index.wxml
+++ b/packages/tabs/index.wxml
@@ -9,7 +9,7 @@
     container="{{ container }}"
     bind:scroll="onTouchScroll"
   >
-    <view class="{{ utils.bem('tabs__wrap', { scrollable }) }} {{ type === 'line' && border ? 'van-hairline--top-bottom' : '' }} {{ utils.bem('tabs--' + type) }} wrap-class">
+    <view class="{{ utils.bem('tabs__wrap', { scrollable }) }} {{ type === 'line' && border ? 'van-hairline--top-bottom' : '' }} {{ 'van-tabs--' + type }} wrap-class">
       <slot name="nav-left" />
 
       <scroll-view


### PR DESCRIPTION
#5200  存在嵌套关系时，dom结构一致，在里层的虽然是line类型的tab标签，但同时满足card类型的样式条件（因为就是在card里层），导致样式被覆盖，从而高度不对。
![image](https://user-images.githubusercontent.com/64689255/233934408-323f9d57-3112-4a03-988c-2bc41e5f1af5.png)
