### PR TITLE
fix(tab): fix tab height 

### DIFF
--- a/packages/empty/test/__snapshots__/demo.spec.ts.snap
+++ b/packages/empty/test/__snapshots__/demo.spec.ts.snap
@@ -56,7 +56,7 @@ exports[`should render demo and match snapshot 1`] = `
         bind:change="onChange"
       >
         <wx-view
-          class="custom-class van-tabs van-tabs--line"
+          class="custom-class van-tabs"
         >
           <van-sticky
             bind:scroll="onTouchScroll"
@@ -70,7 +70,7 @@ exports[`should render demo and match snapshot 1`] = `
                 style="z-index:1"
               >
                 <wx-view
-                  class="van-tabs__wrap  wrap-class"
+                  class="van-tabs--line van-tabs__wrap  wrap-class"
                 >
                   <wx-scroll-view
                     class="van-tabs__scroll van-tabs__scroll--line"

--- a/packages/icon/test/__snapshots__/demo.spec.ts.snap
+++ b/packages/icon/test/__snapshots__/demo.spec.ts.snap
@@ -6,7 +6,7 @@ exports[`should render demo and match snapshot 1`] = `
     bind:change="onSwitch"
   >
     <wx-view
-      class="custom-class van-tabs van-tabs--line"
+      class="custom-class van-tabs"
     >
       <van-sticky
         bind:scroll="onTouchScroll"
@@ -20,7 +20,7 @@ exports[`should render demo and match snapshot 1`] = `
             style="z-index:1"
           >
             <wx-view
-              class="van-tabs__wrap  wrap-class"
+              class="van-tabs--line van-tabs__wrap  wrap-class"
             >
               <wx-scroll-view
                 class="van-tabs__scroll van-tabs__scroll--line"

--- a/packages/index-bar/test/__snapshots__/demo.spec.ts.snap
+++ b/packages/index-bar/test/__snapshots__/demo.spec.ts.snap
@@ -6,7 +6,7 @@ exports[`should render demo and match snapshot 1`] = `
     bind:change="onChange"
   >
     <wx-view
-      class="custom-class van-tabs van-tabs--line"
+      class="custom-class van-tabs"
     >
       <van-sticky
         bind:scroll="onTouchScroll"
@@ -20,7 +20,7 @@ exports[`should render demo and match snapshot 1`] = `
             style="z-index:1"
           >
             <wx-view
-              class="van-tabs__wrap  wrap-class"
+              class="van-tabs--line van-tabs__wrap  wrap-class"
             >
               <wx-scroll-view
                 class="van-tabs__scroll van-tabs__scroll--line"

--- a/packages/tab/test/__snapshots__/demo.spec.ts.snap
+++ b/packages/tab/test/__snapshots__/demo.spec.ts.snap
@@ -15,7 +15,7 @@ exports[`should render demo and match snapshot 1`] = `
         bind:change="onChange"
       >
         <wx-view
-          class="custom-class van-tabs van-tabs--line"
+          class="custom-class van-tabs"
         >
           <van-sticky
             bind:scroll="onTouchScroll"
@@ -29,7 +29,7 @@ exports[`should render demo and match snapshot 1`] = `
                 style="z-index:1"
               >
                 <wx-view
-                  class="van-tabs__wrap  wrap-class"
+                  class="van-tabs--line van-tabs__wrap  wrap-class"
                 >
                   <wx-scroll-view
                     class="van-tabs__scroll van-tabs__scroll--line"
@@ -172,7 +172,7 @@ exports[`should render demo and match snapshot 1`] = `
       </wx-view>
       <van-tabs>
         <wx-view
-          class="custom-class van-tabs van-tabs--line"
+          class="custom-class van-tabs"
         >
           <van-sticky
             bind:scroll="onTouchScroll"
@@ -186,7 +186,7 @@ exports[`should render demo and match snapshot 1`] = `
                 style="z-index:1"
               >
                 <wx-view
-                  class="van-tabs__wrap  wrap-class"
+                  class="van-tabs--line van-tabs__wrap  wrap-class"
                 >
                   <wx-scroll-view
                     class="van-tabs__scroll van-tabs__scroll--line"
@@ -308,7 +308,7 @@ exports[`should render demo and match snapshot 1`] = `
       </wx-view>
       <van-tabs>
         <wx-view
-          class="custom-class van-tabs van-tabs--line"
+          class="custom-class van-tabs"
         >
           <van-sticky
             bind:scroll="onTouchScroll"
@@ -322,7 +322,7 @@ exports[`should render demo and match snapshot 1`] = `
                 style="z-index:1"
               >
                 <wx-view
-                  class="van-tabs__wrap van-tabs__wrap--scrollable  wrap-class"
+                  class="van-tabs--line van-tabs__wrap van-tabs__wrap--scrollable  wrap-class"
                 >
                   <wx-scroll-view
                     class="van-tabs__scroll van-tabs__scroll--line"
@@ -509,7 +509,7 @@ exports[`should render demo and match snapshot 1`] = `
         bind:disabled="onClickDisabled"
       >
         <wx-view
-          class="custom-class van-tabs van-tabs--line"
+          class="custom-class van-tabs"
         >
           <van-sticky
             bind:scroll="onTouchScroll"
@@ -523,7 +523,7 @@ exports[`should render demo and match snapshot 1`] = `
                 style="z-index:1"
               >
                 <wx-view
-                  class="van-tabs__wrap  wrap-class"
+                  class="van-tabs--line van-tabs__wrap  wrap-class"
                 >
                   <wx-scroll-view
                     class="van-tabs__scroll van-tabs__scroll--line"
@@ -647,7 +647,7 @@ exports[`should render demo and match snapshot 1`] = `
         tabClass="special-tab"
       >
         <wx-view
-          class="custom-class van-tabs van-tabs--card"
+          class="custom-class van-tabs"
         >
           <van-sticky
             bind:scroll="onTouchScroll"
@@ -661,7 +661,7 @@ exports[`should render demo and match snapshot 1`] = `
                 style="z-index:1"
               >
                 <wx-view
-                  class="van-tabs__wrap  wrap-class"
+                  class="van-tabs--card van-tabs__wrap  wrap-class"
                 >
                   <wx-scroll-view
                     class="van-tabs__scroll van-tabs__scroll--card"
@@ -781,7 +781,7 @@ exports[`should render demo and match snapshot 1`] = `
         bind:click="onClick"
       >
         <wx-view
-          class="custom-class van-tabs van-tabs--line"
+          class="custom-class van-tabs"
         >
           <van-sticky
             bind:scroll="onTouchScroll"
@@ -795,7 +795,7 @@ exports[`should render demo and match snapshot 1`] = `
                 style="z-index:1"
               >
                 <wx-view
-                  class="van-tabs__wrap  wrap-class"
+                  class="van-tabs--line van-tabs__wrap  wrap-class"
                 >
                   <wx-scroll-view
                     class="van-tabs__scroll van-tabs__scroll--line"
@@ -896,7 +896,7 @@ exports[`should render demo and match snapshot 1`] = `
       </wx-view>
       <van-tabs>
         <wx-view
-          class="custom-class van-tabs van-tabs--line"
+          class="custom-class van-tabs"
         >
           <van-sticky
             bind:scroll="onTouchScroll"
@@ -910,7 +910,7 @@ exports[`should render demo and match snapshot 1`] = `
                 style="z-index:1"
               >
                 <wx-view
-                  class="van-tabs__wrap  wrap-class"
+                  class="van-tabs--line van-tabs__wrap  wrap-class"
                 >
                   <wx-scroll-view
                     class="van-tabs__scroll van-tabs__scroll--line"
@@ -1053,7 +1053,7 @@ exports[`should render demo and match snapshot 1`] = `
       </wx-view>
       <van-tabs>
         <wx-view
-          class="custom-class van-tabs van-tabs--line"
+          class="custom-class van-tabs"
         >
           <van-sticky
             bind:scroll="onTouchScroll"
@@ -1067,7 +1067,7 @@ exports[`should render demo and match snapshot 1`] = `
                 style="z-index:1"
               >
                 <wx-view
-                  class="van-tabs__wrap  wrap-class"
+                  class="van-tabs--line van-tabs__wrap  wrap-class"
                 >
                   <wx-scroll-view
                     class="van-tabs__scroll van-tabs__scroll--line"
@@ -1210,7 +1210,7 @@ exports[`should render demo and match snapshot 1`] = `
       </wx-view>
       <van-tabs>
         <wx-view
-          class="custom-class van-tabs van-tabs--line"
+          class="custom-class van-tabs"
         >
           <van-sticky
             bind:scroll="onTouchScroll"
@@ -1224,7 +1224,7 @@ exports[`should render demo and match snapshot 1`] = `
                 style="z-index:1"
               >
                 <wx-view
-                  class="van-tabs__wrap  wrap-class"
+                  class="van-tabs--line van-tabs__wrap  wrap-class"
                 >
                   <wx-scroll-view
                     class="van-tabs__scroll van-tabs__scroll--line"
@@ -1371,7 +1371,7 @@ exports[`should render demo and match snapshot 1`] = `
         bind:change="onChange"
       >
         <wx-view
-          class="custom-class van-tabs van-tabs--line"
+          class="custom-class van-tabs"
         >
           <van-sticky
             bind:scroll="onTouchScroll"
@@ -1385,7 +1385,7 @@ exports[`should render demo and match snapshot 1`] = `
                 style="z-index:1"
               >
                 <wx-view
-                  class="van-tabs__wrap  wrap-class"
+                  class="van-tabs--line van-tabs__wrap  wrap-class"
                 >
                   <wx-scroll-view
                     class="van-tabs__scroll van-tabs__scroll--line"
@@ -1562,7 +1562,7 @@ exports[`should render demo and match snapshot 1`] = `
         bind:change="onChange"
       >
         <wx-view
-          class="custom-class van-tabs van-tabs--line"
+          class="custom-class van-tabs"
         >
           <van-sticky
             bind:scroll="onTouchScroll"
@@ -1576,7 +1576,7 @@ exports[`should render demo and match snapshot 1`] = `
                 style="z-index:1"
               >
                 <wx-view
-                  class="van-tabs__wrap  wrap-class"
+                  class="van-tabs--line van-tabs__wrap  wrap-class"
                 >
                   <wx-scroll-view
                     class="van-tabs__scroll van-tabs__scroll--line"

--- a/packages/tabs/index.less
+++ b/packages/tabs/index.less
@@ -113,15 +113,11 @@
   }
 
   &--line {
-    .van-tabs__wrap {
-      height: var(--tabs-line-height, @tabs-line-height);
-    }
+    height: var(--tabs-line-height, @tabs-line-height);
   }
 
   &--card {
-    .van-tabs__wrap {
-      height: var(--tabs-card-height, @tabs-card-height);
-    }
+    height: var(--tabs-card-height, @tabs-card-height);
   }
 }
 

--- a/packages/tabs/index.wxml
+++ b/packages/tabs/index.wxml
@@ -1,7 +1,7 @@
 <wxs src="../wxs/utils.wxs" module="utils" />
 <wxs src="./index.wxs" module="computed" />
 
-<view class="custom-class {{ utils.bem('tabs', [type]) }}">
+<view class="custom-class {{ utils.bem('tabs') }}">
   <van-sticky
     disabled="{{ !sticky }}"
     z-index="{{ zIndex }}"
@@ -9,7 +9,7 @@
     container="{{ container }}"
     bind:scroll="onTouchScroll"
   >
-    <view class="{{ utils.bem('tabs__wrap', { scrollable }) }} {{ type === 'line' && border ? 'van-hairline--top-bottom' : '' }} wrap-class">
+    <view class="{{ utils.bem('tabs__wrap', { scrollable }) }} {{ type === 'line' && border ? 'van-hairline--top-bottom' : '' }} {{ utils.bem('tabs--' + type) }} wrap-class">
       <slot name="nav-left" />
 
       <scroll-view

--- a/packages/tabs/index.wxml
+++ b/packages/tabs/index.wxml
@@ -9,7 +9,7 @@
     container="{{ container }}"
     bind:scroll="onTouchScroll"
   >
-    <view class="{{ utils.bem('tabs__wrap', { scrollable }) }} {{ type === 'line' && border ? 'van-hairline--top-bottom' : '' }} {{ utils.bem('tabs--' + type) }} wrap-class">
+    <view class="{{ utils.bem('tabs__wrap', { scrollable }) }} {{ type === 'line' && border ? 'van-hairline--top-bottom' : '' }} {{ 'van-tabs--' + type }} wrap-class">
       <slot name="nav-left" />
 
       <scroll-view

--- a/packages/tabs/index.wxml
+++ b/packages/tabs/index.wxml
@@ -9,7 +9,7 @@
     container="{{ container }}"
     bind:scroll="onTouchScroll"
   >
-    <view class="{{ utils.bem('tabs__wrap', { scrollable }) }} {{ type === 'line' && border ? 'van-hairline--top-bottom' : '' }} {{ 'van-tabs--' + type }} wrap-class">
+    <view class="{{ utils.bem('tabs--') + type }} {{ utils.bem('tabs__wrap', { scrollable }) }} {{ type === 'line' && border ? 'van-hairline--top-bottom' : '' }} wrap-class">
       <slot name="nav-left" />
 
       <scroll-view


### PR DESCRIPTION
#5200 当嵌套使用时，由于最外层使用的card的样式，内层使用line的样式，但内层同样是card里面的一个子元素，导致样式被覆盖，高度就不对了。