### PR TITLE
fix(tab): incorrect slot

### DIFF
--- a/packages/tabs/index.less
+++ b/packages/tabs/index.less
@@ -32,6 +32,7 @@
       --tabs-nav-background-color,
       @tabs-nav-background-color
     );
+    overflow: auto;
 
     &--line {
       box-sizing: content-box;


### PR DESCRIPTION
#4700  scroll-view内容过多时，右侧插槽内容被挤出，将scroll-view的overflow 设置auto， 再由flex自动分配宽度