### PR TITLE
feat(Steps): add simple slot for text and desc

### DIFF
--- a/packages/steps/index.ts
+++ b/packages/steps/index.ts
@@ -2,7 +2,10 @@ import { VantComponent } from '../common/component';
 import { GREEN, GRAY_DARK } from '../common/color';
 
 VantComponent({
-  classes: ['desc-class'],
+  classes: [
+    'text-class',
+    'desc-class',
+  ],
 
   props: {
     icon: String,
@@ -25,6 +28,14 @@ VantComponent({
       value: 'checked',
     },
     inactiveIcon: String,
+    textSlot: {
+      type: Boolean,
+      value: false,
+    },
+    descSlot: {
+        type: Boolean,
+        value: false,
+    }
   },
 
   methods: {

--- a/packages/steps/index.wxml
+++ b/packages/steps/index.wxml
@@ -11,8 +11,14 @@
       style="{{ status(index, active) === 'inactive' ? 'color: ' + inactiveColor: '' }}"
     >
       <view class="van-step__title" style="{{ index === active ? 'color: ' + activeColor : '' }}">
-        <view>{{ item.text }}</view>
-        <view class="desc-class">{{ item.desc }}</view>
+        <view class="text-class">
+          <slot wx:if="{{ textSlot }}" name="text-{{index}}"></slot>
+          <view wx:else>{{ item.text }}</view>
+        </view>
+        <view class="desc-class">
+          <slot wx:if="{{ descSlot }}" name="desc-{{index}}"></slot>
+          <view wx:else>{{ item.desc }}</view>
+        </view>
       </view>
       <view class="van-step__circle-container">
         <block wx:if="{{ index !== active }}">


### PR DESCRIPTION
针对#5368 ，简单的调整，几乎没有测试。（似乎issue说需要重构，望指点）

> 自用片段示例
```html
  <van-steps
    steps="{{ steps }}"
    active="{{ stepActive }}"
    direction="vertical"
    textSlot descSlot 
    active-color="rgba(30, 144, 255, 1.0)" 
    bind:click-step="onClickStep">
    <view wx:for="{{steps}}" slot="text-{{index}}" wx:key="index">
      <view wx:if="{{item.type === 1}}">{{item.text}}</view>
      <view wx:else> {{ type2Str(item.type) }} </view>
    </view>
    <view wx:for="{{steps}}" slot="desc-{{index}}" wx:key="index">
      {{item.desc}}
    </view>
  </van-steps>
```