### PR TITLE
build(deps): bump @vant/icons to v2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@babel/preset-typescript": "^7.16.0",
     "@types/jest": "^27.0.2",
     "@vant/cli": "^4.0.0",
-    "@vant/icons": "^1.7.1",
+    "@vant/icons": "^2.0.0",
     "gulp": "^4.0.2",
     "gulp-insert": "^0.5.0",
     "gulp-less": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2798,10 +2798,10 @@
     eslint-plugin-import "^2.24.0"
     eslint-plugin-vue "^7.18.0"
 
-"@vant/icons@^1.7.1":
-  version "1.8.0"
-  resolved "https://registry.npmmirror.com/@vant/icons/-/icons-1.8.0.tgz#36b13f2e628b533f6523a93a168cf02f07056674"
-  integrity sha512-sKfEUo2/CkQFuERxvkuF6mGQZDKu3IQdj5rV9Fm0weJXtchDSSQ+zt8qPCNUEhh9Y8shy5PzxbvAfOOkCwlCXg==
+"@vant/icons@^2.0.0":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@vant/icons/-/icons-2.0.1.tgz#058eba7ba27deb1aaa0cb6dc5c7b2b2dbc15edb7"
+  integrity sha512-KYzUOSKC/h58ubiCwS6oXhqOBHihtBSTrpCb7o0nl82fKQcRCoaFwGjg5SlnwUNuWA7Wab3/g1UA+g+26LE28A==
 
 "@vant/markdown-vetur@^2.3.0":
   version "2.3.0"


### PR DESCRIPTION
升级 @vant/icons 到 v2，其中主要的破坏性变更只是删除了 .ttf 字体格式。

https://github.com/youzan/vant/blob/main/packages/vant-icons/CHANGELOG.md