### PR TITLE
fix(uploader): fix invalid maxDuration on PC

### DIFF
--- a/packages/uploader/shared.ts
+++ b/packages/uploader/shared.ts
@@ -46,7 +46,7 @@ export const mediaProps = {
   },
   maxDuration: {
     type: Number,
-    value: 60,
+    value: 10,
   },
   camera: {
     type: String,


### PR DESCRIPTION
fix[5438](https://github.com/youzan/vant-weapp/issues/5438)

现阶段小程序PC端仅支持10秒内的 `maxDuration` 值，当前 `uploader` 组件的 `maxDuration` 属性默认值为60秒。
如果在PC端打开的小程序使用 `uploader` 组件上传文件时会无反应。

小程序官方答复:
> PC目前只支持选择10s以内的文件 修改下maxduration看看 后续版本修复

- [wx.chooseMedia一旦设置maxDuration参数，pc端的小程序，无法弹出选择文件的？](https://developers.weixin.qq.com/community/develop/doc/000ee867c50a70c705fd6c75151400)
