### PR TITLE
fix(calendar): fix calendar reset miss default Date

### DIFF
--- a/packages/calendar/index.ts
+++ b/packages/calendar/index.ts
@@ -168,7 +168,7 @@ VantComponent({
 
   methods: {
     reset() {
-      this.setData({ currentDate: this.getInitialDate() });
+      this.setData({ currentDate: this.getInitialDate(this.data.defaultDate) });
       this.scrollIntoView();
     },
 


### PR DESCRIPTION
#5542 
之前reset的时候没有传入defaultDate，进入了 if (!defaultDate) return [] 判断，返回了空。