### PR TITLE
fix(van-notice-bar): notice-bar early vanished when delay and scrollable were set

### DIFF
--- a/lib/notice-bar/index.js
+++ b/lib/notice-bar/index.js
@@ -108,7 +108,7 @@ var utils_1 = require("../common/utils");
             });
             this.timer = setTimeout(function () {
                 _this.scroll();
-            }, this.duration + this.data.delay);
+            }, this.duration);
         },
         onClickIcon: function (event) {
             if (this.data.mode === 'closeable') {

--- a/lib/notice-bar/index.js
+++ b/lib/notice-bar/index.js
@@ -108,7 +108,7 @@ var utils_1 = require("../common/utils");
             });
             this.timer = setTimeout(function () {
                 _this.scroll();
-            }, this.duration);
+            }, this.duration + this.data.delay);
         },
         onClickIcon: function (event) {
             if (this.data.mode === 'closeable') {

--- a/packages/notice-bar/index.ts
+++ b/packages/notice-bar/index.ts
@@ -119,7 +119,7 @@ VantComponent({
 
       this.timer = setTimeout(() => {
         this.scroll();
-      }, this.duration);
+      }, this.duration + this.data.delay);
     },
 
     onClickIcon(event) {


### PR DESCRIPTION
通知栏设置为scrollable且delay>0时，第二次及之后的滚动，内容还未到达顶端就重新播放动画
原因是定时器没有把delay加进去，动画过早重置