### PR TITLE
fix(van-area): 修复组件van-area的columns-num属性类型与文档描述不符的问题

### DIFF
--- a/packages/area/index.ts
+++ b/packages/area/index.ts
@@ -193,7 +193,7 @@ VantComponent({
 
       const stack: Promise<void>[] = [];
       const indexes: number[] = [];
-      const { columnsNum } = this.data;
+      const columnsNum = Number(this.data.columnsNum);
 
       if (columnsNum >= 1) {
         stack.push(picker.setColumnValues(0, provinceList, false));


### PR DESCRIPTION
### Pull Request 标题规则

fix(van-area): 修复组件van-area的columns-num属性类型与文档描述不符的问题
https://github.com/youzan/vant-weapp/issues/5621
