### PR TITLE
FIX: (action-sheet) closeOnClickOverlay property not working

### DIFF
--- a/dist/action-sheet/index.js
+++ b/dist/action-sheet/index.js
@@ -63,9 +63,11 @@ VantComponent({
         onClose() {
             this.$emit('close');
         },
-        onClickOverlay() {
+        onClickOverlay: function () {
+          if (this.data.closeOnClickOverlay) {
             this.$emit('click-overlay');
             this.onClose();
+          }
         },
     },
 });

--- a/lib/action-sheet/index.js
+++ b/lib/action-sheet/index.js
@@ -67,8 +67,11 @@ var button_1 = require("../mixins/button");
             this.$emit('close');
         },
         onClickOverlay: function () {
-            this.$emit('click-overlay');
-            this.onClose();
+          const _this = this;
+          if (_this.data.closeOnClickOverlay) {
+            _this.$emit('click-overlay');
+            _this.onClose();
+          }
         },
     },
 });


### PR DESCRIPTION
issue:  [https://github.com/youzan/vant-weapp/issues/1544](https://github.com/youzan/vant-weapp/issues/1544)

check whether `closeOnClickOverlay` prop is set to `true` before close action-sheet


