### PR TITLE
fix: 修复按需加载下popup弹窗内容区被遮罩层盖住

### DIFF
--- a/packages/popup/index.wxs
+++ b/packages/popup/index.wxs
@@ -4,7 +4,7 @@ var style = require('../wxs/style.wxs');
 function popupStyle(data) {
   return style([
     {
-      'z-index': data.zIndex,
+      'z-index': data.zIndex + 1,
       '-webkit-transition-duration': data.currentDuration + 'ms',
       'transition-duration': data.currentDuration + 'ms',
     },


### PR DESCRIPTION
### 修复按需加载下popup弹窗内容区被遮罩层盖住

- fix(Popup): 增加动态层级

可选择的类型:

- fix

app.json中增加按需注入配置，vant-weapp会出现内容区在遮罩层下方，导致无法点击到内容区。