### PR TITLE
feat(Upload): support mix mediaType

### DIFF
--- a/packages/uploader/README.md
+++ b/packages/uploader/README.md
@@ -244,7 +244,7 @@ uploadFilePromise(fileName, chooseResult) {
 | camera | 当 accept 为 `video` \| `media` 时生效，可选值为 `back` `front` | _string_ | - |
 | compressed | 当 accept 为 `video` 时生效，是否压缩视频，默认为`true` | _boolean_ | - |
 | max-duration | 当 accept 为 `video` \| `media` 时生效，拍摄视频最长拍摄时间，单位秒 | _number_ | `60` |
-| media-type `v1.10.8` | 当 accept 为 `media` 时生效，选择的文件的文件类型，可选值为 `image` `video` | _string[]_ | `['image', 'video']` |
+| media-type `v1.10.8` | 当 accept 为 `media` 时生效，选择的文件的文件类型，可选值为 `image` `video` `mix` | _string[]_ | `['image', 'video', 'mix']` |
 | extension `v1.10.11` | 当 accept 为 `file` 时生效，根据文件拓展名过滤可选择文件。每一项都不能是空字符串。默认不过滤 | _string[] \| undefined_ | - |
 | showmenu `v1.10.13` | 预览图片时，是否显示长按菜单 | _boolean_ | `true` |
 | upload-icon | 上传区域图标，可选值见 [Icon 组件](#/icon) | _string_ | `plus` |

--- a/packages/uploader/shared.ts
+++ b/packages/uploader/shared.ts
@@ -42,7 +42,7 @@ export const mediaProps = {
   },
   mediaType: {
     type: Array,
-    value: ['image', 'video'],
+    value: ['image', 'video', 'mix'],
   },
   maxDuration: {
     type: Number,

--- a/packages/uploader/utils.ts
+++ b/packages/uploader/utils.ts
@@ -73,9 +73,10 @@ function formatVideo(
 function formatMedia(res: WechatMiniprogram.ChooseMediaSuccessCallbackResult) {
   return res.tempFiles.map((item) => ({
     ...pickExclude(item, ['fileType', 'thumbTempFilePath', 'tempFilePath']),
-    type: res.type,
+    type: item.fileType,
     url: item.tempFilePath,
-    thumb: res.type === 'video' ? item.thumbTempFilePath : item.tempFilePath,
+    thumb:
+      item.fileType === 'video' ? item.thumbTempFilePath : item.tempFilePath,
   }));
 }
 


### PR DESCRIPTION
#5675 
当medieType 存在 'mix'时，formatMedia函数的入参res的type值会是mix。type改成当前项item的fileType准确判断是image还是video，后续走进isImageFile/isVideoFile的判断，通过了这两项判断才能在模板上显示。