### PR TITLE
fix(van-toast): 解决Toast.clear失效问题，van-toast的数据应该定义在data中，而非props。

### DIFF
--- a/packages/toast/index.ts
+++ b/packages/toast/index.ts
@@ -1,29 +1,18 @@
 import { VantComponent } from '../common/component';
 
 VantComponent({
-  props: {
-    show: Boolean,
-    mask: Boolean,
-    message: String,
-    forbidClick: Boolean,
-    zIndex: {
-      type: Number,
-      value: 1000,
-    },
-    type: {
-      type: String,
-      value: 'text',
-    },
-    loadingType: {
-      type: String,
-      value: 'circular',
-    },
-    position: {
-      type: String,
-      value: 'middle',
-    },
+  data: {
+    show: false,
+    type: 'text',
+    mask: false,
+    message: '',
+    zIndex: 1000,
+    duration: 2000,
+    position: 'middle',
+    forbidClick: false,
+    loadingType: 'circular',
+    selector: '#van-toast',
   },
-
   methods: {
     // for prevent touchmove
     noop() {},

--- a/packages/toast/index.ts
+++ b/packages/toast/index.ts
@@ -11,7 +11,6 @@ VantComponent({
     position: 'middle',
     forbidClick: false,
     loadingType: 'circular',
-    selector: '#van-toast',
   },
   methods: {
     // for prevent touchmove

--- a/packages/toast/index.ts
+++ b/packages/toast/index.ts
@@ -7,7 +7,6 @@ VantComponent({
     mask: false,
     message: '',
     zIndex: 1000,
-    duration: 2000,
     position: 'middle',
     forbidClick: false,
     loadingType: 'circular',


### PR DESCRIPTION
修复Toast.clear失效问题，van-toast的数据由toast.js中的setData改变，是否van-toast的数据应该定义在data中？而非props中。

经测试，把van-toast中props的数据迁移至data中，可以解决Toast.clear引起的异常问题（如无法关闭toast、关闭toast之后无法再打开等）