### PR TITLE
fix(van-stepper): 组件van-stepper在设置最大值后onChange事件监听到的值超出max的问题

### DIFF
--- a/packages/stepper/index.ts
+++ b/packages/stepper/index.ts
@@ -168,7 +168,7 @@ VantComponent({
         const pair = formatted.split('.');
         formatted = `${pair[0]}.${pair[1].slice(0, this.data.decimalLength)}`;
       }
-
+      formatted = this.format(formatted);
       this.emitChange(formatted);
     },
 


### PR DESCRIPTION
### Pull Request 标题规则

fix(van-stepper): 组件van-stepper在设置最大值后onChange事件监听到的值超出max的问题

解决issue: https://github.com/youzan/vant-weapp/issues/5737
