### PR TITLE
fix(van-stepper):  fix onChange event exceeded 'max' after setting the max prop

### DIFF
--- a/packages/stepper/index.ts
+++ b/packages/stepper/index.ts
@@ -161,13 +161,7 @@ VantComponent({
         return;
       }
 
-      let formatted = this.filter(value);
-
-      // limit max decimal length
-      if (isDef(this.data.decimalLength) && formatted.indexOf('.') !== -1) {
-        const pair = formatted.split('.');
-        formatted = `${pair[0]}.${pair[1].slice(0, this.data.decimalLength)}`;
-      }
+      let formatted = this.format(value);
 
       this.emitChange(formatted);
     },


### PR DESCRIPTION
fix(van-stepper): 组件van-stepper在设置最大值后onChange事件监听到的值超出max的问题

解决issue: https://github.com/youzan/vant-weapp/issues/5737