### PR TITLE
fix(Transition): fix cannot find method observeDuration

### DIFF
--- a/packages/mixins/transition.ts
+++ b/packages/mixins/transition.ts
@@ -23,7 +23,6 @@ export function transition(showDefaultValue: boolean) {
       duration: {
         type: null,
         value: 300,
-        observer: 'observeDuration',
       },
       name: {
         type: String,


### PR DESCRIPTION
fix(Transition): fix cannot find method observeDuration

解决discussions: #5695 