### PR TITLE
chore(workflow): generate changelog via GitHub

### DIFF
--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -1,0 +1,10 @@
+"change: feat":
+  - "/^(feat|types|style)/"
+"change: fix":
+  - "/^fix/"
+"change: perf":
+  - "/^perf/"
+"change: breaking":
+  - "/^breaking change/"
+"change: docs":
+  - "/^docs/"

--- a/.github/workflows/pr-label.yaml
+++ b/.github/workflows/pr-label.yaml
@@ -1,0 +1,20 @@
+name: PR Labeler
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+
+jobs:
+  change-labeling:
+    name: Labeling for changes
+    runs-on: ubuntu-latest
+    steps:
+      - uses: github/issue-labeler@v3.4
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          configuration-path: .github/pr-labeler.yml
+          enable-versioned-regex: 0
+          include-title: 1
+          sync-labels: 1

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -11,13 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
+
       - name: Create Release for Tag
         id: release_tag
-        uses: yyx990803/release-tag@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: ncipollo/release-action@v1
         with:
-          tag_name: ${{ github.ref }}
+          generateReleaseNotes: "true"
           body: |
-            更新内容参见 [CHANGELOG](https://vant-ui.github.io/vant-weapp/#/changelog)。
+            > 请访问 [更新日志](https://vant-ui.github.io/vant-weapp/#/changelog) 了解所有更新。

--- a/build/release.sh
+++ b/build/release.sh
@@ -28,7 +28,4 @@ then
   else 
     npm publish
   fi
-
-  # changelog
-  vant-cli changelog
 fi

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "release": "sh build/release.sh",
     "release:site": "vant-cli build-site && gh-pages -d site-dist --add",
     "build:lib": "yarn && npx gulp -f build/compiler.js --series buildEs buildLib",
-    "build:changelog": "vant-cli changelog",
     "upload:weapp": "node build/upload.js",
     "test": "jest",
     "test:watch": "jest --watch"


### PR DESCRIPTION
## 背景

与 vant 仓库对齐，使用 GitHub 来生成标准的 CHANGELOG 格式。

1. 通过 actions，自动给 PR 打上分类的 label，比如 feature、bugfix
2. 通过 actions，自动在创建 GitHub release tag 时生成 changelog，类似如下格式：

![image](https://github.com/youzan/vant-weapp/assets/7237365/14208795-2974-4501-9b9e-0c5b8d67f2d4)

## 手动生成

GitHub 也支持手动生成 changelog，步骤如下：

1. 打开 https://github.com/youzan/vant-weapp/releases
2. 新建或编辑一个 tag
3. 选取上一个 tag，点击 generate 即可

![image](https://github.com/youzan/vant-weapp/assets/7237365/e3c69405-5874-47ea-b4d5-a1fbe0f4f1a9)
