### PR TITLE
fix(Stepper): can't show minus and plus in a real phone

### DIFF
--- a/packages/stepper/index.less
+++ b/packages/stepper/index.less
@@ -38,7 +38,7 @@
       bottom: 0;
       left: 0;
       margin: auto;
-      background-color: currentColor;
+      background-color: var(--stepper-button-icon-color, @stepper-button-icon-color);
       content: '';
     }
 
@@ -55,6 +55,13 @@
         --stepper-button-disabled-color,
         @stepper-button-disabled-color
       );
+
+      &::before, &::after {
+        background-color: var(
+        --stepper-button-disabled-icon-color,
+        @stepper-button-disabled-icon-color
+      ) !important;
+      }
     }
 
     &--disabled&--hover {


### PR DESCRIPTION
bug 详情: https://github.com/youzan/vant-weapp/issues/5821

在开发工具中可正常显示。但是在Android机上无法显示

