### PR TITLE
docs: fix the recommended global font-family

### DIFF
--- a/packages/common/README.md
+++ b/packages/common/README.md
@@ -65,7 +65,7 @@ Vant 中默认包含了一些常用样式，可以直接通过 className 的方�
 ```css
 page {
   font-family: -apple-system, BlinkMacSystemFont, 'Helvetica Neue', Helvetica,
-    Segoe UI, Arial, Roboto, 'PingFang SC', 'miui', 'Hiragino Sans GB', 'Microsoft Yahei',
-    sans-serif;
+    'Segoe UI', Arial, Roboto, 'PingFang SC', 'miui', 'Hiragino Sans GB',
+    'Microsoft Yahei', sans-serif;
 }
 ```


### PR DESCRIPTION
`Segoe UI` -> `'Segoe UI'`

font-family取值

[`<family-name>`](https://developer.mozilla.org/zh-CN/docs/Web/CSS/font-family#family-name)
一个字体族的名字。例如"Times" 和 "Helvetica" 都是字体族名。字体族名可以**包含空格**，但**包含空格时应该用引号**。

[`<generic-name>`](https://developer.mozilla.org/zh-CN/docs/Web/CSS/font-family#generic-name)
通用字体族名是一种备选机制，用于在指定的字体不可用时给出较好的字体。通用字体族名都是**关键字**，所以**不可以加引号**。在列表的末尾应该至少有一个通用字体族名。以下是该属性可能的取值以及他们的定义。