### PR TITLE
fix(field): update field Props to fix wechat warning

### DIFF
--- a/packages/field/input.wxml
+++ b/packages/field/input.wxml
@@ -6,7 +6,6 @@
   focus="{{ focus }}"
   cursor="{{ cursor }}"
   value="{{ innerValue }}"
-  auto-focus="{{ autoFocus }}"
   disabled="{{ disabled || readonly }}"
   maxlength="{{ maxlength }}"
   placeholder="{{ placeholder }}"

--- a/packages/field/props.ts
+++ b/packages/field/props.ts
@@ -12,7 +12,6 @@ export const commonProps: WechatMiniprogram.Component.PropertyOption = {
     type: Number,
     value: 50,
   },
-  autoFocus: Boolean,
   focus: Boolean,
   cursor: {
     type: Number,


### PR DESCRIPTION
fix(field)：update field Props to fix wechat warning

description: 
when using field component, the WeChat Dev Tool reported this:
<img width="1004" alt="field-warning" src="https://github.com/user-attachments/assets/717cb10a-00d2-4059-ae23-0ca9239a15f0">
