### PR TITLE
fix(Cascader):Type issue of option[this. data. valueKey]

### DIFF
--- a/lib/cascader/index.js
+++ b/lib/cascader/index.js
@@ -108,7 +108,8 @@ var defaultFieldNames = {
         getSelectedOptionsByValue: function (options, value) {
             for (var i = 0; i < options.length; i++) {
                 var option = options[i];
-                if (option[this.data.valueKey] === value) {
+                var optionValueKey = String(option[this.data.valueKey]);
+                if (optionValueKey === value) {
                     return [option];
                 }
                 if (option[this.data.childrenKey]) {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/755c2d57-7e72-471a-853a-6c39bc57f7de)

`const options = [
  {
    text: '浙江省',
    value: 330000,
    children: [{ text: '杭州市', value: 330100 }],
  },
  {
    text: '江苏省',
    value: 320000,
    children: [{ text: '南京市', value: 320100 }],
  },
]`

如图在options数组的value为number情况下出现