### PR TITLE
fix(ActionSheet): wrong event binding for close icon

### DIFF
--- a/packages/action-sheet/index.wxml
+++ b/packages/action-sheet/index.wxml
@@ -17,7 +17,7 @@
     <van-icon
       name="cross"
       custom-class="van-action-sheet__close"
-      bind:click="onClose"
+      bind:click="onCancel"
     />
   </view>
   <view wx:if="{{ description }}" class="van-action-sheet__description van-hairline--bottom">


### PR DESCRIPTION
fix(ActionSheet): wrong event binding for close icon
关闭图标应该绑定cancel 
![image](https://github.com/user-attachments/assets/fed9f9c2-3a38-4c12-b396-da0c1659090b)





