### PR TITLE
fix(dialog): fix dialog beforeClose not work when use use-confirm-button

### DIFF
--- a/packages/dialog/index.ts
+++ b/packages/dialog/index.ts
@@ -95,7 +95,19 @@ VantComponent({
     },
 
     onClickOverlay() {
-      this.close('overlay');
+      const { asyncClose, beforeClose } = this.data;
+      const CLOSE_ACTION = 'overlay';
+      if (!asyncClose && !beforeClose) {
+        this.close(CLOSE_ACTION);
+        return;
+      }
+      if (beforeClose) {
+        toPromise(beforeClose(CLOSE_ACTION)).then((value) => {
+          if (value) {
+            this.close(CLOSE_ACTION);
+          }
+        });
+      }
     },
 
     close(action: string) {


### PR DESCRIPTION
[https://github.com/youzan/vant-weapp/issues/6025](url)
