### PR TITLE
fix(datetime-picker): update change event to include detailed parameters in the emitted event

### DIFF
--- a/packages/datetime-picker/README.md
+++ b/packages/datetime-picker/README.md
@@ -200,7 +200,7 @@ Page({
 | 事件名称 | 说明                     | 回调参数   |
 | -------- | ------------------------ | ---------- |
 | bind:input    | 当值变化时触发的事件     | 当前 value |
-| bind:change   | 当值变化时触发的事件     | 组件实例   |
+| bind:change   | 当值变化时触发的事件     | {picker: 组件实例, value: Array, index: 触发修改的列索引}   |
 | bind:confirm  | 点击完成按钮时触发的事件 | 当前 value |
 | bind:cancel   | 点击取消按钮时触发的事件 | -          |
 

--- a/packages/datetime-picker/index.ts
+++ b/packages/datetime-picker/index.ts
@@ -42,7 +42,7 @@ function getMonthEndDay(year: number, month: number): number {
 
 const defaultFormatter = (
   type: 'year' | 'month' | 'day' | 'hour' | 'minute',
-  value: string
+  value: string,
 ) => value;
 
 VantComponent({
@@ -172,20 +172,10 @@ VantComponent({
         ];
       }
 
-      const {
-        maxYear,
-        maxDate,
-        maxMonth,
-        maxHour,
-        maxMinute,
-      } = this.getBoundary('max', data.innerValue);
-      const {
-        minYear,
-        minDate,
-        minMonth,
-        minHour,
-        minMinute,
-      } = this.getBoundary('min', data.innerValue);
+      const { maxYear, maxDate, maxMonth, maxHour, maxMinute } =
+        this.getBoundary('max', data.innerValue);
+      const { minYear, minDate, minMonth, minHour, minMinute } =
+        this.getBoundary('min', data.innerValue);
 
       const result = [
         {
@@ -288,7 +278,7 @@ VantComponent({
       this.$emit('confirm', this.data.innerValue);
     },
 
-    onChange() {
+    onChange(event) {
       const { data } = this;
       let value;
 
@@ -302,7 +292,7 @@ VantComponent({
       } else {
         const indexes = picker.getIndexes();
         const values = indexes.map(
-          (value, index) => originColumns[index].values[value]
+          (value, index) => originColumns[index].values[value],
         );
         const year = getTrueValue(values[0]);
         const month = getTrueValue(values[1]);
@@ -324,7 +314,7 @@ VantComponent({
 
       this.updateColumnValue(value).then(() => {
         this.$emit('input', value);
-        this.$emit('change', picker);
+        this.$emit('change', { ...event.detail, picker });
       });
     },
 
@@ -350,7 +340,7 @@ VantComponent({
           values.push(
             formatter('day', padZero(date.getDate())),
             formatter('hour', padZero(date.getHours())),
-            formatter('minute', padZero(date.getMinutes()))
+            formatter('minute', padZero(date.getMinutes())),
           );
         }
       }


### PR DESCRIPTION
# fix(datetime-picker): update change event to include detailed parameters in the emitted event
## 场景
实现当切换的日 非当天，设置默认的时间为上班时间八点半

## 问题
目前无法获取到触发修改的列索引，在`picker`组件内看到了参数的传递，但是在`datetime-picker`进行了覆盖，覆盖的内容属于 `picker`传递的事件参数子集, 也就是仅包含了 `picker` 实例，不如直接传递