### PR TITLE
feat(button): 添加 loadingColor 属性支持自定义 loading 图标颜色

### DIFF
--- a/packages/button/README.md
+++ b/packages/button/README.md
@@ -136,6 +136,7 @@
 | loading-text | 加载状态提示文字 | _string_ | - |
 | loading-type | 加载状态图标类型，可选值为 `spinner` | _string_ | `circular` |
 | loading-size | 加载图标大小 | _string_ | `20px` |
+| loading-color | 加载图标颜色 | _string_ | - |
 | custom-style | 自定义样式 | _string_ | - |
 | open-type | 微信开放能力，具体支持可参考 [微信官方文档](https://developers.weixin.qq.com/miniprogram/dev/component/button.html) | _string_ | - |
 | app-parameter | 打开 APP 时，向 APP 传递的参数 | _string_ | - |

--- a/packages/button/index.ts
+++ b/packages/button/index.ts
@@ -50,6 +50,7 @@ VantComponent({
       value: '20px',
     },
     color: String,
+    loadingColor: String,
   },
 
   methods: {

--- a/packages/button/index.wxml
+++ b/packages/button/index.wxml
@@ -34,7 +34,7 @@
       custom-class="loading-class"
       size="{{ loadingSize }}"
       type="{{ loadingType }}"
-      color="{{ computed.loadingColor({ type, color, plain }) }}"
+      color="{{ computed.loadingColor({ loadingColor, type, color, plain }) }}"
     />
     <view wx:if="{{ loadingText }}" class="van-button__loading-text">
       {{ loadingText }}

--- a/packages/button/index.wxs
+++ b/packages/button/index.wxs
@@ -22,6 +22,10 @@ function rootStyle(data) {
 }
 
 function loadingColor(data) {
+  if (data.loadingColor) {
+    return data.loadingColor;
+  }
+
   if (data.plain) {
     return data.color ? data.color : '#c9c9c9';
   }


### PR DESCRIPTION
## 背景

当前 button 组件的 loading 图标颜色是根据 `type`、`color`、`plain` 属性计算的，但在某些场景下（如自定义了 color 属性后），计算得到的颜色与按钮背景色对比度不足，影响视觉效果。

## 改动

1. 新增 `loadingColor` 属性，支持自定义 loading 图标颜色
2. 当未指定 loadingColor 时，保持原有计算逻辑
3. 在文档中新增了 `loadingColor` 属性说明

## 备注

此改动应该完全向后兼容，不影响现有代码。